### PR TITLE
Wayland-first: clipboard, typing, screen capture, display info + CI tooling

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -189,7 +189,7 @@ jobs:
 
         - Linux x86_64
         - FUSE support (for AppImage execution)
-        - X11 display server
+        - Wayland compositor (preferred) or X11 (fallback)
         - .NET 8.0 runtime (bundled in AppImage)
 
         ### Usage

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -208,7 +208,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y xvfb libx11-dev libxrandr-dev
+        sudo apt-get install -y xvfb libx11-dev libxrandr-dev wl-clipboard grim slurp wtype
 
     - name: Build application
       run: |

--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -6,12 +6,12 @@ Reviewed README.md, ROADMAP.md, SPECIFICATION.md, MCP_SPECIFICATION.md, docs/*.m
 Found occurrences in README, roadmap, workflows, implementation guide, code (xdotool, xrandr), clipboard tools, tests.
 3. ✅ Replace X11 with Wayland in Markdown files
 Updated README system requirements, workflow AppImage readme, implementation guide wording.
-4. 🔄 Replace X11 with Wayland in code where applicable
-Wayland-first implementations: screen capture (grim/swaymsg/hyprctl), clipboard (wl-copy/wl-paste first), cursor position (Wayland-first shim). Need to review input simulation click/type (xdotool) for Wayland alternatives.
-5. 🔄 Assess Wayland alternatives to X11 functionality
-Will document libraries/tools and C# binding strategies.
-6. 🔄 Assess clipboard integration via MCP (user->agent and agent->user)
-Will verify tool behavior and describe MCP path.
-7. ⏳ Commit changes to repo with appropriate message
+4. ✅ Replace X11 with Wayland in code where applicable
+Wayland-first: grim capture, swaymsg/hyprctl display info, wl-clipboard clipboard, Wayland cursor attempts; X11 kept as fallback.
+5. ✅ Assess Wayland alternatives to X11 functionality
+Documented alternatives: grim/slurp, wl-clipboard, swaymsg/hyprctl/wayland-info, kscreen-doctor, xdg-desktop-portal (Screenshot/ScreenCast/RemoteDesktop), PipeWire, wtype/ydotool. C# interop via Tmds.DBus.
+6. ✅ Assess clipboard integration via MCP (user->agent and agent->user)
+Confirmed implemented tools get_clipboard/set_clipboard. Wayland-first via wl-clipboard. ModeManager may require confirmation. Supports text format currently.
+7. ✅ Commit changes to repo with appropriate message
 
 

--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -1,31 +1,17 @@
 # Task List
 
-1. ✅ Implement native HTTP transport using ModelContextProtocol.AspNetCore
-✅ COMPLETED: Successfully implemented native HTTP transport with Server-Sent Events streaming. All tests passing: initialize, tools list, tool execution, screenshot capture, and multi-client support.
-2. ✅ Implement multi-monitor support with display detection
-✅ COMPLETED: Successfully implemented multi-monitor support with xrandr/xdpyinfo detection, coordinate translation, monitor-specific overlays and screenshots. All tests passing.
-3. ✅ Update documentation to reflect STDIO deprecation
-✅ COMPLETED: Updated MCP_SPECIFICATION.md to reflect that HTTP is now the primary transport and STDIO is deprecated (kept for testing only).
-4. ✅ Implement missing MCP tools: re_anchor_element and get_display_info
-✅ COMPLETED: Both tools successfully implemented and tested. get_display_info provides comprehensive display detection. re_anchor_element supports absolute/relative positioning with boundary clamping.
-5. ✅ Test native HTTP transport implementation
-✅ COMPLETED: Comprehensive testing successful. HTTP transport working with SSE streaming, multi-client support, CORS, and all MCP protocol features.
-6. ✅ Update MCP_SPECIFICATION.md to match actual implementation
-✅ COMPLETED: Updated tool count to 15, marked multi-monitor support as implemented, updated HTTP transport documentation, and corrected endpoint URLs.
-7. ⏳ Wire scenario-based testing from YAML files
-Connect tests/ai-gui/scenarios/basic.yaml to feed test parameters and create comprehensive test scenarios.
-8. ⏳ Document the working raw JSON client approach
-Create documentation explaining why raw JSON client works vs official SDK, and provide usage examples.
-9. ⏳ Clean up temporary test files
-Remove debug and test files that are no longer needed
-10. ✅ Test multi-monitor functionality once implemented
-✅ COMPLETED: Comprehensive multi-monitor testing successful. Display detection, coordinate translation, monitor-specific overlays and screenshots all working.
-11. ✅ Implement re_anchor_element MCP tool
-✅ COMPLETED: Successfully implemented with absolute/relative positioning modes, boundary clamping, and monitor support. All tests passing.
-12. ✅ Add Python linting workflow for multi-language support
-✅ COMPLETED: Created comprehensive python-lint.yml workflow with Black, flake8, mypy, bandit, safety, isort, and pylint. Follows existing workflow patterns with path-based triggers and caching.
-13. ✅ Fix AppImage build failure in CI/CD pipeline
-✅ COMPLETED: Fixed AppStream metadata validation by using reverse DNS notation (io.github.ryansopensaucerice.overlay-companion-mcp), added developer info and content rating, improved error handling to accept validation warnings, and fixed desktop category to use single main category.
-14. ✅ Set up automatic development environment for AllHands instances
-✅ COMPLETED: Created setup-dev-environment.sh script that automatically installs pre-commit hooks, sets up Python virtual environment, installs dependencies, and configures quality checks. Updated all specification files with setup instructions for AI agents.
+1. ✅ Read all README and documentation files
+Reviewed README.md, ROADMAP.md, SPECIFICATION.md, MCP_SPECIFICATION.md, docs/*.md. Identified X11 mentions and existing Wayland support (clipboard).
+2. ✅ Search repository for 'X11' occurrences (code + markdown)
+Found occurrences in README, roadmap, workflows, implementation guide, code (xdotool, xrandr), clipboard tools, tests.
+3. ✅ Replace X11 with Wayland in Markdown files
+Updated README system requirements, workflow AppImage readme, implementation guide wording.
+4. 🔄 Replace X11 with Wayland in code where applicable
+Wayland-first implementations: screen capture (grim/swaymsg/hyprctl), clipboard (wl-copy/wl-paste first), cursor position (Wayland-first shim). Need to review input simulation click/type (xdotool) for Wayland alternatives.
+5. 🔄 Assess Wayland alternatives to X11 functionality
+Will document libraries/tools and C# binding strategies.
+6. 🔄 Assess clipboard integration via MCP (user->agent and agent->user)
+Will verify tool behavior and describe MCP path.
+7. ⏳ Commit changes to repo with appropriate message
+
 

--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -14,4 +14,3 @@ Documented alternatives: grim/slurp, wl-clipboard, swaymsg/hyprctl/wayland-info,
 Confirmed implemented tools get_clipboard/set_clipboard. Wayland-first via wl-clipboard. ModeManager may require confirmation. Supports text format currently.
 7. ✅ Commit changes to repo with appropriate message
 
-

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ A general-purpose, human-in-the-loop AI-assisted screen interaction toolkit buil
 3. Run: `./overlay-companion-mcp-*.AppImage`
 
 ### System Requirements
-- Linux with X11 display server
-- xrandr (for multi-monitor support)
+- Linux (Wayland preferred; X11 supported as fallback)
+- Wayland compositor (e.g., GNOME, KDE, Sway, Hyprland)
+- Recommended tools: grim (Wayland), gnome-screenshot/spectacle; scrot/maim (X11 fallback)
 - Modern desktop environment (GNOME, KDE, XFCE, etc.)
 
 ## Usage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -152,7 +152,7 @@ app.MapMcp();  // Registers /mcp endpoint with streaming support
 ## 🛠️ **Technical Implementation Notes**
 
 ### Multi-Monitor Implementation Strategy:
-1. **Linux**: Use `xrandr` to detect monitors, `DISPLAY` environment for targeting
+1. **Linux**: Prefer Wayland compositor APIs (hyprctl, swaymsg, wayland-info) with X11 `xrandr` as fallback
 2. **Cross-platform**: Abstract monitor detection behind `IDisplayService`
 3. **Coordinate mapping**: Transform screen coordinates between monitors
 4. **Overlay positioning**: Ensure overlays appear on correct monitor

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -14,10 +14,10 @@
 - **Jan.ai Client** - AI model integration via MCP protocol
 
 ### Linux Integration
-- **X11/Wayland** - Native Linux window management
-- **xdotool** - Mouse and keyboard automation
-- **gnome-screenshot/scrot/maim** - Screen capture utilities
-- **xrandr** - Multi-monitor support
+- **Wayland-first (X11 fallback)** - Linux window management and compositors
+- **wtype/ydotool (Wayland) / xdotool (X11)** - Mouse and keyboard automation
+- **grim/spectacle/gnome-screenshot (Wayland) / scrot/maim (X11)** - Screen capture utilities
+- **swaymsg/hyprctl/wayland-info (Wayland) / xrandr (X11)** - Multi-monitor support
 - **gsettings** - HiDPI detection
 
 ## Project Structure

--- a/src/MCP/Tools/GetClipboardTool.cs
+++ b/src/MCP/Tools/GetClipboardTool.cs
@@ -56,13 +56,13 @@ public static class GetClipboardTool
     {
         try
         {
-            // Use xclip to get clipboard content on Linux
+            // Prefer Wayland clipboard first
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "xclip",
-                    Arguments = "-selection clipboard -o",
+                    FileName = "wl-paste",
+                    Arguments = "--no-newline",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -81,18 +81,18 @@ public static class GetClipboardTool
         }
         catch
         {
-            // Try alternative clipboard tools
+            // Try X11 clipboard tools next
         }
 
         try
         {
-            // Try wl-paste for Wayland
+            // Fallback to xclip on X11
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "wl-paste",
-                    Arguments = "--no-newline",
+                    FileName = "xclip",
+                    Arguments = "-selection clipboard -o",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,

--- a/src/MCP/Tools/SetClipboardTool.cs
+++ b/src/MCP/Tools/SetClipboardTool.cs
@@ -66,13 +66,12 @@ public static class SetClipboardTool
     {
         try
         {
-            // Use xclip to set clipboard content on Linux
+            // Prefer Wayland clipboard first
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "xclip",
-                    Arguments = "-selection clipboard",
+                    FileName = "wl-copy",
                     UseShellExecute = false,
                     RedirectStandardInput = true,
                     RedirectStandardError = true,
@@ -92,17 +91,18 @@ public static class SetClipboardTool
         }
         catch
         {
-            // Try alternative clipboard tools
+            // Try X11 clipboard tools next
         }
 
         try
         {
-            // Try wl-copy for Wayland
+            // Fallback to xclip on X11
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "wl-copy",
+                    FileName = "xclip",
+                    Arguments = "-selection clipboard",
                     UseShellExecute = false,
                     RedirectStandardInput = true,
                     RedirectStandardError = true,

--- a/src/Services/InputMonitorService.cs
+++ b/src/Services/InputMonitorService.cs
@@ -245,19 +245,56 @@ public class InputMonitorService : IInputMonitorService
     /// </summary>
     public async Task<bool> SimulateTypingAsync(string text, int typingSpeedWpm = 60)
     {
+        // Calculate delay between characters based on WPM
+        // Average word length is 5 characters, so WPM * 5 = characters per minute
+        var charactersPerMinute = Math.Max(typingSpeedWpm * 5, 1);
+        var delayMs = 60000 / charactersPerMinute; // milliseconds per character
+        var escaped = text.Replace("\"", "\\\"");
+
+        // Wayland-first: try wtype
         try
         {
-            // Calculate delay between characters based on WPM
-            // Average word length is 5 characters, so WPM * 5 = characters per minute
-            var charactersPerMinute = typingSpeedWpm * 5;
-            var delayMs = 60000 / charactersPerMinute; // milliseconds per character
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "wtype",
+                    Arguments = $"-d {delayMs} -- \"{escaped}\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
 
+            process.Start();
+            await process.WaitForExitAsync();
+            if (process.ExitCode == 0)
+            {
+                var inputEvent = new InputEvent
+                {
+                    Position = GetCurrentMousePosition(),
+                    EventType = "key",
+                    Data = text
+                };
+                KeyPressed?.Invoke(this, inputEvent);
+                return true;
+            }
+        }
+        catch
+        {
+            // fall through to X11 fallback
+        }
+
+        // Fallback: xdotool (X11)
+        try
+        {
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "xdotool",
-                    Arguments = $"type --delay {delayMs} \"{text.Replace("\"", "\\\"")}\"",
+                    Arguments = $"type --delay {delayMs} \"{escaped}\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -270,7 +307,6 @@ public class InputMonitorService : IInputMonitorService
 
             if (process.ExitCode == 0)
             {
-                // Fire key event
                 var inputEvent = new InputEvent
                 {
                     Position = GetCurrentMousePosition(),

--- a/tests/ai-gui/setup.sh
+++ b/tests/ai-gui/setup.sh
@@ -12,8 +12,8 @@ python -m pip install --upgrade pip >/dev/null
 # Try install minimal apt packages (best effort)
 if command -v apt-get >/dev/null 2>&1; then
   (sudo apt-get update -y || apt-get update -y) >/dev/null || true
-  (sudo apt-get install -y xvfb xauth imagemagick xdotool libx11-6 libxext6 libxrender1 libxi6 libxrandr2 libxtst6 libxcb1 libgl1 libfontconfig1 fonts-dejavu-core || \
-   apt-get install -y xvfb xauth imagemagick xdotool libx11-6 libxext6 libxrender1 libxi6 libxrandr2 libxtst6 libxcb1 libgl1 libfontconfig1 fonts-dejavu-core) >/dev/null || true
+  (sudo apt-get install -y xvfb xauth imagemagick xdotool libx11-6 libxext6 libxrender1 libxi6 libxrandr2 libxtst6 libxcb1 libgl1 libfontconfig1 fonts-dejavu-core wl-clipboard grim slurp wtype || \
+   apt-get install -y xvfb xauth imagemagick xdotool libx11-6 libxext6 libxrender1 libxi6 libxrandr2 libxtst6 libxcb1 libgl1 libfontconfig1 fonts-dejavu-core wl-clipboard grim slurp wtype) >/dev/null || true
 fi
 
 # Python deps (keep minimal)


### PR DESCRIPTION
Summary
- Make Wayland the preferred target across docs and code while keeping X11 as a fallback.
- Add Wayland typing via wtype, Wayland clipboard via wl-clipboard, Wayland screen capture via grim, and Wayland display detection via hyprctl/swaymsg.
- Update CI and test setup to include Wayland tooling.

Key Changes
- Docs:
  - README.md, docs/IMPLEMENTATION_GUIDE.md: Wayland-first requirements and tooling guidance.
  - ROADMAP.md: Multi-monitor strategy now prefers compositor APIs (hyprctl/swaymsg/wayland-info) over xrandr.
  - .github/workflows/build-appimage.yml: Notes updated to Wayland preferred.
- Clipboard:
  - GetClipboardTool/SetClipboardTool prefer wl-paste/wl-copy; fallback to xclip.
- Input:
  - InputMonitorService.SimulateTypingAsync uses wtype first; falls back to xdotool.
- Display & Capture:
  - GetDisplayInfoTool queries hyprctl/swaymsg first, then xrandr/xdpyinfo.
  - ScreenCaptureService prefers grim; supports GNOME/KDE tools; X11 fallbacks kept.
- CI/Tests:
  - .github/workflows/ci-cd.yml: Install wl-clipboard, grim, slurp, wtype for integration tests.
  - tests/ai-gui/setup.sh: Install Wayland tools (wl-clipboard, grim, slurp, wtype).

Security & Safety
- No RDP or remote server added.
- Portal-based input (xdg-desktop-portal) is not included; if needed later, will be optional and disabled by default.

Notes
- dotnet-format pre-commit hook is present but may not run locally where dotnet is unavailable; CI handles .NET formatting checks.
- Future optional work: portal-based input behind a flag, headless Wayland session for CI.

Co-authored-by: openhands <openhands@all-hands.dev>

@RyansOpenSauceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37e7a50729c04d7d9a2b109346af6449)