### PR TITLE
Wayland-first + CI GUI smoke tests (Xvfb and Weston headless)

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -286,14 +286,14 @@ jobs:
     - name: Install test dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y fuse libfuse2 xvfb
+        sudo apt-get install -y fuse libfuse2 xvfb weston xwayland
 
-    - name: Test AppImage execution
+    - name: Test AppImage execution and extraction
       run: |
         cd test
         chmod +x ${{ needs.build-appimage.outputs.appimage-name }}
 
-        # Test basic execution with virtual display
+        # Test basic execution with virtual display (help)
         xvfb-run -a ./${{ needs.build-appimage.outputs.appimage-name }} --help || echo "Help test completed"
 
         # Test AppImage extraction
@@ -304,5 +304,15 @@ jobs:
         test -f squashfs-root/AppRun
         test -f squashfs-root/usr/bin/overlay-companion-mcp
         test -f squashfs-root/*.desktop
+
+    - name: Smoke test (X11/Xvfb)
+      run: |
+        chmod +x tests/local-appimage-smoke.sh
+        xvfb-run -a bash tests/local-appimage-smoke.sh ./test/${{ needs.build-appimage.outputs.appimage-name }}
+
+    - name: Smoke test (Wayland via weston headless + Xwayland)
+      run: |
+        chmod +x tests/ci/appimage-smoke-weston.sh || true
+        bash tests/ci/appimage-smoke-weston.sh ./test/${{ needs.build-appimage.outputs.appimage-name }}
 
         echo "✅ AppImage tests passed"

--- a/tests/ci/appimage-smoke-weston.sh
+++ b/tests/ci/appimage-smoke-weston.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPIMAGE_PATH="${1:?AppImage path required}"
+if [ ! -f "$APPIMAGE_PATH" ]; then
+  echo "AppImage not found: $APPIMAGE_PATH" >&2
+  exit 1
+fi
+
+export XDG_RUNTIME_DIR="$HOME/.xdg-runtime"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# Start weston in headless mode with Xwayland
+weston --backend=headless --xwayland --idle-time=0 --socket=wayland-ci --log=/tmp/weston.log &
+WESTON_PID=$!
+trap 'kill $WESTON_PID >/dev/null 2>&1 || true' EXIT
+
+# Give weston time to start
+sleep 3
+
+# Export Wayland env and run the AppImage with smoke-test
+export WAYLAND_DISPLAY=wayland-ci
+export AVALONIA_PLATFORM=Wayland
+export AVALONIA_USE_WAYLAND=1
+export OC_WINDOW_READY_FILE=/tmp/oc_window_ready_wayland.txt
+
+set +e
+"$APPIMAGE_PATH" --smoke-test > /tmp/appimage-wayland.log 2>&1 &
+PID=$!
+set -e
+
+for i in $(seq 1 40); do
+  if [ -f "$OC_WINDOW_READY_FILE" ]; then
+    echo "✅ Wayland window-ready detected: $OC_WINDOW_READY_FILE"
+    kill $PID >/dev/null 2>&1 || true
+    exit 0
+  fi
+  sleep 1
+  if ! kill -0 $PID >/dev/null 2>&1; then
+    echo "❌ AppImage process exited early. Logs:" >&2
+    tail -n +1 /tmp/appimage-wayland.log || true
+    exit 1
+  fi
+
+done
+
+echo "❌ No Wayland window-ready signal within timeout. Logs:" >&2
+echo "--- weston.log ---" >&2
+head -n 200 /tmp/weston.log || true
+
+echo "--- appimage-wayland.log ---" >&2
+head -n 200 /tmp/appimage-wayland.log || true
+exit 1


### PR DESCRIPTION
# Pull Request

## Description
Add CI smoke tests to exercise the AppImage in two environments:
- X11 via Xvfb
- Wayland via headless weston + Xwayland

Also keeps the prior Wayland-first code and SPEC changes.

## Type of Change
- [x] Test coverage improvement
- [x] Documentation update

## Changes Made
- .github/workflows/build-appimage.yml
  - Installs xvfb, weston, xwayland
  - Runs existing local-appimage-smoke.sh under Xvfb
  - Adds a weston headless smoke test job to validate an Avalonia Wayland window appears
- tests/ci/appimage-smoke-weston.sh: helper to start weston headless and verify OC_WINDOW_READY_FILE is set

## MCP Specification Impact
- [x] No changes to MCP specification

## Testing
- [x] Local bash smoke test exists (tests/local-appimage-smoke.sh)
- [x] CI smoke tests for Xvfb and weston headless

## Documentation
- [x] README: concise, defers to SPEC for platform
- [x] SPEC: Wayland-first with X11 fallback details present

## Checklist
- [x] My changes generate no new warnings
- [x] New tests verify window readiness

## Privacy and Security
- [x] No new privacy/security concerns introduced

## Performance Impact
- [x] No performance impact

## Additional Notes
- If weston headless packages are not available on ubuntu-latest image in the future, we may need to pin versions or add an alternate compositor.

## Related Issues
Fixes # (link if applicable)

@RyansOpenSauceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/37e7a50729c04d7d9a2b109346af6449)