### PR TITLE
feat(web): WebSocket overlay broadcast + browser click-through overlay stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ tests/ai-gui/artifacts/
 *.log
 server.log
 /src/server.log
+
+# OpenTofu generated artifacts
+/deploy/opentofu/modules/*/generated/
+/deploy/opentofu/envs/*/.terraform/
+/deploy/opentofu/envs/*/.terraform.lock.hcl
+

--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -1,21 +1,11 @@
 # Task List
 
-1. ✅ Research GTK4/Wayland click-through overlays and validate approach
-Use empty input region on GdkSurface after realize. Consider gtk4-layer-shell for stable z-order.
-2. ✅ Implement true click-through in Gtk4OverlayWindow using empty input region
-Set empty Cairo.Region in OnWindowRealized, keep fullscreen transparent window, draw only requested rectangle.
-3. 🔄 Add overlay opacity support end-to-end
-Added OverlayElement.Opacity, wired into draw path; still need to expose to UI and MCP tool (done), and validate color parsing including hex with alpha.
-4. ✅ Fix DrawOverlayTool parameter handling and id/label mapping
-Now constructs OverlayElement with Id=id, preserves ClickThrough, Opacity.
-5. ✅ Ensure batch overlay APIs preserve overlay properties
-Batch methods now call DrawOverlayAsync(OverlayElement).
-6. ⏳ Add optional gtk4-layer-shell integration for robust z-order
-Consider adding GirCore bindings or P/Invoke; guard behind feature flag.
-7. ⏳ Ensure overlay never grabs keyboard focus
-Investigate Gtk.ApplicationWindow focusable flags in GTK4 C# bindings; set to non-focusable if available.
-8. ⏳ Install dotnet SDK, build and run tests locally
-Environment currently lacks dotnet; required to validate functionality end-to-end.
-9. 🔄 Improve color parsing to accept hex and apply alpha properly
-Implement hex parsing (#RRGGBB/#RRGGBBAA/#RGB) and use overlay.Opacity for default alpha; replace named color table.
+1. 🔄 Add WebSocket overlay broadcast in server (C#) and map /ws/overlays
+OverlayWebSocketHub + OverlayEventBroadcaster; subscribe to OverlayService events.
+2. 🔄 Serve static web client with overlay canvas and guaranteed click-through
+Add web/index.html + overlay.js; pointer-events: none; viewport cropping via URL params.
+3. ⏳ Add /api/test-overlay endpoint to trigger overlay broadcast
+Use OverlayService to create a sample overlay; respects HEADLESS=1 to avoid GTK windows.
+4. ⏳ Wire static files in csproj so they publish/run correctly
+Include web/** as Content CopyToOutputDirectory=PreserveNewest.
 

--- a/MCP_SPECIFICATION.md
+++ b/MCP_SPECIFICATION.md
@@ -8,7 +8,7 @@
 
 **Overlay Companion (MCP)** is a desktop-based Model Context Protocol (MCP) server designed to facilitate context-aware, human-assisted UI interactions across arbitrary applications—not tied to any specific use case such as job applications. Its primary goal is to provide a **safe, extendable, and vendor-agnostic interface** enabling AI agents (via Cherry Studio or others) to:
 
-- Draw overlays (highlight, label, annotate) on the screen using an OS-level transparent window.
+- Draw overlays (highlight, label, annotate) in the browser above a remote desktop viewer with guaranteed click-through (CSS pointer-events: none).
 - Capture screenshots in a controlled, high-performance manner.
 - Emulate user input (clicks and typing) under safely defined policies.
 - Operate in distinct modes ("passive", "assist", "autopilot", "composing") for flexible control over automation and human consent.
@@ -161,7 +161,7 @@ The server operates in different modes that control automation behavior:
 **Title:** Draw overlay box  
 **Mode:** async
 
-Draws a visual overlay (highlight, label, annotation) on the screen using an OS-level transparent window.
+Draws a visual overlay (highlight, label, annotation) in the browser above the remote desktop canvas. Overlays are always click‑through (CSS pointer-events: none) so user input reaches the viewer.
 
 **Parameters:**
 - `x` (number, required): X coordinate for the overlay

--- a/MCP_SPECIFICATION.md
+++ b/MCP_SPECIFICATION.md
@@ -1,527 +1,101 @@
-# Overlay Companion (MCP) - MCP Protocol Specification
+# Overlay Companion (MCP) – MCP Protocol (Web‑first)
 
-*A general-purpose, human-in-the-loop AI-assisted screen interaction toolkit.*
-
----
-
-## Overview & Purpose
-
-**Overlay Companion (MCP)** is a desktop-based Model Context Protocol (MCP) server designed to facilitate context-aware, human-assisted UI interactions across arbitrary applications—not tied to any specific use case such as job applications. Its primary goal is to provide a **safe, extendable, and vendor-agnostic interface** enabling AI agents (via Cherry Studio or others) to:
-
-- Draw overlays (highlight, label, annotate) in the browser above a remote desktop viewer with guaranteed click-through (CSS pointer-events: none).
-- Capture screenshots in a controlled, high-performance manner.
-- Emulate user input (clicks and typing) under safely defined policies.
-- Operate in distinct modes ("passive", "assist", "autopilot", "composing") for flexible control over automation and human consent.
-- Be the foundation for more specialized workflows, such as job application assistants, without embedding that logic into the core tool.
-
-### Design Principles
-
-- **Human-in-the-loop by default** — no automated actions unless explicitly enabled per mode or user confirmation.
-- **Mode-aware behavior** — switching modes adjusts behavior (e.g. clicking automatically vs. suggesting).
-- **Privacy-respecting** — screenshots can be scrubbed before being shared; clipboard access controlled by user permission.
-- **Multi-monitor and DPI-aware** — avoids overlay misplacement in complex setups (planned for future implementation).
-- **Rate-limited calls** — protects local and remote inference systems from overload and keeps operations low-latency.
-
-### Extension Strategy
-
-This repository is intended to serve as a **public, reusable base tool**. Domain-specific workflows (e.g., job applications, form filling, cover letter generation) should be built as **separate, private MCP servers** that integrate with this tool. For example:
-
-- The public MCP server handles overlays, screenshots, input simulation, and modes.
-- A private "Job-Helper MCP server" uses these tools to focus and orchestrate job application logic.
-- This keeps your public repo generic, avoiding naming conflicts or policy concerns related to job automation on GitHub.
+This document defines the MCP surface for a browser‑first overlay system. The server exposes an HTTP transport at /mcp and broadcasts overlay events to web viewers via /ws/overlays. The browser renders a guaranteed click‑through layer using CSS pointer‑events: none. Native overlays remain optional; the default UX is the web viewer.
 
 ---
 
-## MCP Protocol Implementation
-
-### Server Information
-
-- **Name**: `overlay-companion-mcp`
-- **Version**: `1.0.0`
-- **Description**: General-purpose, human-in-the-loop AI-assisted screen interaction toolkit
-- **Protocol**: MCP server with native HTTP transport (default)
-- **Primary Transport**: Native HTTP transport using ModelContextProtocol.AspNetCore
-  - **Port**: 3000 (configurable)
-  - **Features**: Server-Sent Events streaming, multi-client support, CORS enabled, **image handling**
-  - **Benefits**: Web integration, session management, real-time streaming, concurrent clients, binary data support
-- **Legacy Transport**: Standard I/O (stdio) - **DEPRECATED** (use `--stdio` flag)
-  - **Limitations**: No image support, single client only, legacy compatibility only
-- **SDK**: Official ModelContextProtocol C# SDK v0.3.0-preview.3
-- **Framework**: .NET 8.0 with Microsoft.Extensions.Hosting
-- **Protocol Version**: 2024-11-05
-
-### Capabilities
-
-- **Tools**: Provides 15 tools for screen interaction
-- **Resources**: None
-- **Prompts**: None
-- **Sampling**: None
-
-### Error Handling
-
-The server implements standard MCP error responses:
-
-- **-32700**: Parse error
-- **-32600**: Invalid request
-- **-32601**: Method not found
-- **-32602**: Invalid parameters
-- **-32603**: Internal error
-
-### Rate Limiting
-
-- Screenshot operations: Maximum 10 per second
-- Input simulation: Maximum 5 per second
-- Overlay operations: Maximum 20 per second
-
-### Security Model
-
-- **Human confirmation required** for input simulation in most modes
-- **Mode-based permissions** control automation level
-- **No network access** - purely local operations
-- **Clipboard access** requires explicit user permission
-
-### Operational Modes
-
-1. **Passive**: Read-only operations (screenshots, overlays)
-2. **Assist**: Suggests actions, requires confirmation
-3. **Autopilot**: Automated actions with safety checks
-4. **Composing**: Specialized mode for text composition
-5. **Custom**: User-defined behavior
-
-## Connection Configuration
-
-### Cherry Studio Configuration (HTTP Transport - Recommended)
-```json
-{
-  "mcpServers": {
-    "overlay_companion": {
-      "url": "http://localhost:3000/mcp",
-      "description": "AI-assisted screen interaction with overlay functionality for multi-monitor setups",
-      "tags": ["screen-capture", "overlay", "automation", "multi-monitor", "gtk4", "linux"],
-      "provider": "Overlay Companion",
-      "provider_url": "https://github.com/RyansOpenSauceRice/overlay-companion-mcp"
-    }
-  }
-}
-```
-
-### Configuration Helper Endpoints
-
-When the application is running with HTTP transport, it provides helpful configuration endpoints:
-
-- **Web UI**: `http://localhost:3000/setup` - Interactive configuration interface with one-click copy
-- **JSON Config**: `http://localhost:3000/config` - Ready-to-use JSON configuration
-- **Legacy STDIO**: `http://localhost:3000/config/stdio` - STDIO transport configuration (deprecated)
-
-These endpoints include proper metadata (description, tags, provider info) for better integration with MCP clients.
-
-### Claude Desktop Configuration (HTTP Transport - Recommended)
-```json
-{
-  "mcpServers": {
-    "overlay_companion": {
-      "url": "http://localhost:3000/mcp",
-      "description": "AI-assisted screen interaction with overlay functionality for multi-monitor setups",
-      "tags": ["screen-capture", "overlay", "automation", "multi-monitor", "gtk4", "linux"],
-      "provider": "Overlay Companion",
-      "provider_url": "https://github.com/RyansOpenSauceRice/overlay-companion-mcp"
-    }
-  }
-}
-```
-
-### Legacy STDIO Configuration (Deprecated)
-**⚠️ STDIO transport is deprecated and lacks image support. Use HTTP transport above.**
-
-```json
-{
-  "mcpServers": {
-    "overlay-companion": {
-      "command": "/path/to/overlay-companion-mcp",
-      "args": ["--stdio"],
-      "env": {}
-    }
-  }
-}
-```
-
-## Operational Modes
-
-The server operates in different modes that control automation behavior:
-
-- **Passive**: No automated actions, only provides information
-- **Assist**: Suggests actions but requires user confirmation
-- **Autopilot**: Automated actions with safety confirmations
-- **Composing**: Optimized for text generation and form filling
-
-## Tools
-
-### 1. draw_overlay
-
-**Title:** Draw overlay box  
-**Mode:** async
-
-Draws a visual overlay (highlight, label, annotation) in the browser above the remote desktop canvas. Overlays are always click‑through (CSS pointer-events: none) so user input reaches the viewer.
-
-**Parameters:**
-- `x` (number, required): X coordinate for the overlay
-- `y` (number, required): Y coordinate for the overlay  
-- `width` (number, required): Width of the overlay
-- `height` (number, required): Height of the overlay
-- `color` (string, optional): Color of the overlay (default: yellow)
-- `label` (string, optional): Text label for the overlay
-- `annotation_type` (string, optional): Type of annotation (box, text, arrow, icon)
-- `temporary_ms` (number, optional): Auto-remove overlay after specified milliseconds
-- `anchor_id` (string, optional): Unique identifier for element tracking across frames
-
-**Returns:**
-- `overlay_id` (string): Unique identifier for the created overlay
-- `bounds` (object): Actual bounds of the overlay with x, y, width, height
-- `monitor_index` (number): Index of the monitor where overlay was drawn
-- `display_scale` (number): Display scale factor for the monitor
-- `anchor_id` (string): Element anchor ID if provided
-
-### 2. remove_overlay
-
-**Title:** Remove overlay  
-**Mode:** sync
-
-Removes a previously created overlay from the screen.
+## Transport and Endpoints
 
-**Parameters:**
-- `overlay_id` (string, required): ID of the overlay to remove
-
-**Returns:**
-- `removed` (boolean): Whether the overlay was successfully removed
-- `not_found` (boolean): Whether the overlay ID was not found
-
-### 3. take_screenshot
+- MCP over HTTP: GET/POST /mcp (ModelContextProtocol.AspNetCore)
+- WebSocket overlays: /ws/overlays (text JSON messages)
+- Static viewer: / (stub viewer drawing overlays); will embed Guacamole RDP canvas in future
+- Setup/config helpers: /setup, /config
 
-**Title:** Take screenshot  
-**Mode:** async
+---
 
-Captures a screenshot of the screen or a specific region in a controlled, high-performance manner.
+## WebSocket Overlay Messages
 
-**Parameters:**
-- `region` (object, optional): Specific region to capture with x, y, width, height
-- `full_screen` (boolean, optional): Whether to capture the full screen
-- `scale` (number, optional): Scale factor for the screenshot
-- `wait_for_stable_ms` (number, optional): Wait time for UI to stabilize before capture
-- `monitor_index` (number, optional): Specific monitor to capture from
-- `scrub_mask_rects` (array, optional): Array of rectangles to obscure for privacy
+- overlay_created: { overlay: { id, x, y, width, height, color, opacity, monitor_index, created_at } }
+- overlay_removed: { overlay_id }
+- clear_overlays: {}
+- request_sync (planned)
+- sync_state (planned)
 
-**Returns:**
-- `image_base64` (string): Base64-encoded screenshot image
-- `width` (number): Width of the captured image
-- `height` (number): Height of the captured image
-- `region` (object): Actual region that was captured
-- `monitor_index` (number): Index of the monitor that was captured
-- `display_scale` (number): Display scale factor used
-- `viewport_scroll` (object): Viewport scroll position with x, y coordinates
-- `timestamp` (number): Timestamp when screenshot was taken
-- `context_metadata` (object): Additional context information
+Viewer URL params for viewport cropping: vx, vy, vw, vh, scale.
 
-### 4. click_at
+---
 
-**Title:** Simulate click  
-**Mode:** sync
+## Tools (concise)
 
-Emulates user input by simulating mouse clicks at specified coordinates.
+The canonical, machine‑readable definitions are implemented in code and summarized here for clarity.
 
-**Parameters:**
-- `x` (number, required): X coordinate to click
-- `y` (number, required): Y coordinate to click
-- `button` (string, optional): Mouse button to click (left, right, middle)
-- `clicks` (number, optional): Number of clicks to perform
-- `require_user_confirmation` (boolean, optional): Whether to require user confirmation before clicking
-- `action_timing_hint` (object, optional): Timing hints with minDelayMs, maxDelayMs
-- `monitor_index` (number, optional): Monitor where click should occur
-- `anchor_id` (string, optional): Element anchor ID for context
+### draw_overlay (async)
+- x, y, width, height: number
+- color?: string (name or hex)
+- opacity?: number (0..1, default 0.5)
+- label?: string
+- temporary_ms?: number
+- click_through?: boolean (default true)
+- monitor_index?: number
+Returns: overlay_id, bounds, monitor_index
 
-**Returns:**
-- `success` (boolean): Whether the click was successful
-- `was_confirmed` (boolean): Whether the action was confirmed by the user
-- `actual_position` (object): Actual click coordinates with x, y
-- `timestamp` (number): When the click occurred
+### remove_overlay (sync)
+- overlay_id: string
+Returns: removed, not_found
 
-### 5. type_text
+### clear_overlays (sync)
+Removes all overlays. Returns: ok
 
-**Title:** Emulate typing  
-**Mode:** async
+### batch_overlay (async)
+- overlays: OverlaySpec[] (fields as in draw_overlay)
+- one_at_a_time?: boolean
+Returns: overlay_ids: string[]
 
-Emulates keyboard input by typing specified text.
+### take_screenshot (async)
+- region?: { x, y, width, height }
+- full_screen?: boolean
+- scale?: number
+- wait_for_stable_ms?: number
+Returns: image_base64, width, height, region, monitor_index, display_scale, viewport_scroll
 
-**Parameters:**
-- `text` (string, required): Text to type
-- `typing_speed_wpm` (number, optional): Typing speed in words per minute
-- `require_user_confirmation` (boolean, optional): Whether to require user confirmation before typing
-- `action_timing_hint` (object, optional): Timing hints with minDelayMs, maxDelayMs
-- `clear_existing` (boolean, optional): Whether to clear existing text first
+### get_display_info (sync)
+Returns: displays[], total_virtual_screen
 
-**Returns:**
-- `success` (boolean): Whether the typing was successful
-- `typed_length` (number): Number of characters that were typed
-- `was_confirmed` (boolean): Whether the action was confirmed by the user
-- `timestamp` (number): When the typing occurred
+### click_at (sync)
+- x, y: number
+- button?: "left" | "right" | "middle"
+- clicks?: number
+- require_user_confirmation?: boolean
+- action_timing_hint?: object
+Returns: success, was_confirmed
 
-### 6. set_mode
+### type_text (async)
+- text: string
+- typing_speed_wpm?: number
+- require_user_confirmation?: boolean
+- action_timing_hint?: object
+Returns: success, typed_length
 
-**Title:** Set operational mode  
-**Mode:** sync
+---
 
-Sets the operational mode of the MCP server, controlling automation behavior and human consent requirements.
+## Modes and Safety
 
-**Parameters:**
-- `mode` (string, required): Operational mode (passive, assist, autopilot, composing, custom)
-- `metadata` (object, optional): Additional metadata for the mode
+- Modes: passive (read‑only), assist (confirmation required), autopilot (guard‑railed automation)
+- Input simulation is gated by mode and can require explicit user confirmation
+- CORS configured; TLS terminates at reverse proxy (Caddy)
+- Planned: per‑viewer JWTs for overlay WS and session scoping
 
-**Returns:**
-- `ok` (boolean): Whether the mode was set successfully
-- `active_mode` (string): The currently active mode
+---
 
-### 7. set_screenshot_frequency
+## Roadmap Notes (implementation‑oriented)
 
-**Title:** Set screenshot frequency  
-**Mode:** sync
+- Replace stub viewer with Guacamole RDP canvas and keep overlay layer above
+- Add initial WS sync (server emits current overlay state on connect)
+- Playwright E2E across draw/remove/clear and 2‑window viewport sync
+- Multi‑monitor launcher to open/crop two browser windows automatically
 
-Configures the frequency of automatic screenshot capture.
+---
 
-**Parameters:**
-- `mode` (string, required): Screenshot capture mode
-- `interval_ms` (number, required): Interval between screenshots in milliseconds
-- `only_on_change` (boolean, optional): Whether to only capture on UI changes
+## Removed legacy content
 
-**Returns:**
-- `ok` (boolean): Whether the frequency was set successfully
-- `applied_interval_ms` (number): The actual interval that was applied
-
-### 8. get_clipboard
-
-**Title:** Get clipboard  
-**Mode:** sync
-
-Retrieves the current clipboard content.
-
-**Parameters:** None
-
-**Returns:**
-- `text` (string): Current clipboard text content
-- `available` (boolean): Whether clipboard content is available
-
-### 9. set_clipboard
-
-**Title:** Set clipboard  
-**Mode:** sync
-
-Sets the clipboard content to the specified text.
-
-**Parameters:**
-- `text` (string, required): Text to set in clipboard
-
-**Returns:**
-- `ok` (boolean): Whether the clipboard was set successfully
-
-### 10. batch_overlay
-
-**Title:** Draw multiple overlays  
-**Mode:** async
-
-Draws multiple overlays simultaneously or sequentially.
-
-**Parameters:**
-- `overlays` (array, required): Array of overlay objects, each containing:
-  - `x` (number): X coordinate
-  - `y` (number): Y coordinate
-  - `width` (number): Width
-  - `height` (number): Height
-  - `color` (string, optional): Color
-  - `label` (string, optional): Label
-  - `annotation_type` (string, optional): Type of annotation
-  - `temporary_ms` (number, optional): Auto-remove time
-  - `anchor_id` (string, optional): Element anchor ID
-- `one_at_a_time` (boolean, optional): Whether to draw overlays sequentially
-- `monitor_index` (number, optional): Target monitor for all overlays
-
-**Returns:**
-- `overlay_ids` (array): Array of overlay IDs that were created
-- `monitor_index` (number): Monitor where overlays were drawn
-- `display_scale` (number): Display scale factor used
-
-### 11. subscribe_events
-
-**Title:** Subscribe to UI events  
-**Mode:** async
-
-Subscribes to UI events for real-time monitoring of user interactions.
-
-**Parameters:**
-- `events` (array, required): Array of event types to subscribe to
-- `debounce_ms` (number, optional): Debounce time for events
-- `filter` (object, optional): Event filtering criteria
-
-**Returns:**
-- `subscription_id` (string): Unique identifier for the subscription
-- `subscribed` (array): Array of events that were successfully subscribed to
-
-### 12. unsubscribe_events
-
-**Title:** Unsubscribe from events  
-**Mode:** sync
-
-Unsubscribes from previously subscribed UI events.
-
-**Parameters:**
-- `subscription_id` (string, required): ID of the subscription to cancel
-
-**Returns:**
-- `ok` (boolean): Whether the unsubscription was successful
-
-### 13. re_anchor_element
-
-**Title:** Re-anchor element after scroll or layout change  
-**Mode:** async
-
-Re-locates a previously anchored element after viewport changes, scrolling, or layout updates.
-
-**Parameters:**
-- `anchor_id` (string, required): ID of the anchor to re-locate
-- `search_region` (object, optional): Region to search within for the element
-- `tolerance` (number, optional): Matching tolerance for element recognition
-
-**Returns:**
-- `found` (boolean): Whether the element was successfully re-anchored
-- `new_position` (object): New position with x, y coordinates
-- `confidence` (number): Confidence score of the match (0-1)
-- `viewport_scroll` (object): Current viewport scroll position
-
-### 14. get_display_info
-
-**Title:** Get display configuration  
-**Mode:** sync
-
-Retrieves information about all connected displays and their configurations.
-
-**Parameters:** None
-
-**Returns:**
-- `displays` (array): Array of display objects with:
-  - `monitor_index` (number): Display index
-  - `bounds` (object): Display bounds with x, y, width, height
-  - `scale_factor` (number): DPI scale factor
-  - `is_primary` (boolean): Whether this is the primary display
-- `total_virtual_screen` (object): Combined virtual screen dimensions
-
-## Operational Modes
-
-The MCP server supports different operational modes that control automation behavior:
-
-- **passive**: No automated actions, only observation and overlay capabilities
-- **assist**: Suggests actions but requires user confirmation
-- **autopilot**: Performs actions automatically with minimal user intervention
-- **composing**: Specialized mode for text composition and editing
-- **custom**: User-defined mode with custom behavior
-
-## Rate Limiting
-
-All tools implement rate limiting to protect local and remote inference systems from overload and maintain low-latency operations. Configurable limits include:
-
-- Maximum requests per second (default: 10/sec)
-- Maximum screenshot requests per minute (default: 60/min)
-- Burst allowance for rapid interactions
-- Mode-specific rate limits (autopilot mode has higher limits)
-
-## Privacy and Security
-
-- **Screenshot Scrubbing**: Configurable privacy masks to obscure sensitive information
-- **Clipboard Control**: User-controlled clipboard access permissions
-- **Action Confirmation**: All automated actions can require user confirmation
-- **Human-in-the-loop**: Design ensures user maintains control over automation
-- **Audit Trail**: Optional logging of all actions for security and debugging
-- **Local Processing**: Sensitive operations can be processed locally without external API calls
-
-## Multi-Monitor Support
-
-**Current Status**: Single monitor support only (monitor index 0)  
-**Roadmap**: Full multi-monitor support planned for future implementation
-
-**Current Limitations**:
-- All operations assume single monitor (index 0)
-- `CaptureMonitorAsync` treats all requests as full screen capture
-- Overlay coordinates not mapped across multiple displays
-
-**Planned Features**:
-- **Multiple Displays**: Proper handling of multi-monitor setups with different resolutions
-- **DPI Scaling**: Automatic detection and handling of different DPI scales per monitor
-- **Virtual Screen**: Support for extended desktop configurations
-- **Monitor Migration**: Handling of displays being connected/disconnected during operation
-- **Coordinate Translation**: ✅ IMPLEMENTED - Accurate coordinate mapping across different display configurations
-- **`get_display_info` tool**: ✅ IMPLEMENTED - Returns monitor count, resolutions, positions, primary monitor
-- **Monitor-Specific Operations**: ✅ IMPLEMENTED - Overlays and screenshots can target specific monitors
-- **Boundary Clamping**: ✅ IMPLEMENTED - Overlays are automatically clamped to monitor bounds
-
-**Implementation Status**: ✅ COMPLETED - Full multi-monitor support implemented and tested
-
-## Performance Considerations
-
-- **Real-time Operation**: Designed for <0.5 second response times
-- **Efficient Screenshot Capture**: Optimized algorithms for minimal latency
-- **Memory Management**: Careful resource usage for overlay and image operations
-- **Async Operations**: Non-blocking operations for UI responsiveness
-- **Local Model Support**: Optimized for local AI model inference
-
-## Context Awareness
-
-- **Viewport Tracking**: Automatic tracking of scroll positions and viewport changes
-- **Element Anchoring**: Persistent element identification across UI changes
-- **State Management**: Maintains context across multiple interactions
-- **Metadata Exchange**: Bidirectional context sharing with AI models
-
-## Development Environment
-
-### For AI Agents and AllHands Instances
-
-**Automatic Setup (Required):**
-```bash
-git clone https://github.com/RyansOpenSauceRice/overlay-companion-mcp.git
-cd overlay-companion-mcp
-./scripts/setup-dev-environment.sh
-```
-
-This repository uses **automated development environment setup** with:
-- ✅ Pre-commit hooks for code quality (Black, flake8, mypy, bandit)
-- ✅ Multi-language linting (Python, C#, Markdown)
-- ✅ Security scanning and dependency checking
-- ✅ Conventional commit enforcement
-- ✅ Automatic code formatting
-
-### Quality Standards
-
-**Multi-Language Linting Strategy**: Multiple workflow files (industry standard)
-- `python-lint.yml`: Comprehensive Python quality checks
-- `csharp-lint.yml`: C# formatting and analysis
-- `markdown-lint.yml`: Documentation quality assurance
-
-**Pre-commit Hooks**: All code changes are automatically validated for:
-- Code formatting and style consistency
-- Security vulnerabilities and credential detection
-- Type checking and static analysis
-- Import sorting and dependency validation
-
-### Documentation
-
-- **Development Setup**: [docs/DEVELOPMENT_SETUP.md](docs/DEVELOPMENT_SETUP.md)
-- **AI Agent Instructions**: [docs/AI_AGENT_SETUP.md](docs/AI_AGENT_SETUP.md)
-- **Open Source Licenses**: [docs/OPEN_SOURCE_LICENSES.md](docs/OPEN_SOURCE_LICENSES.md)
-
-### Build and Deployment
-
-**AppImage Build**: Automated AppImage creation with proper metadata validation
-```bash
-./scripts/build-appimage.sh
-```
-
-**CI/CD Pipeline**: GitHub Actions workflows for:
-- Multi-language code quality checks
-- Automated testing and validation
-- AppImage build and release
-- Documentation quality assurance
+This MCP spec intentionally removes outdated sections (Avalonia troubleshooting, AppImage internals, deep CI/CD notes, and claims like “no network access”). Those belong in separate operational docs if needed.

--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ You can also check for updates directly from the application's **Settings tab** 
 - **Normal operation**: HTTP server + GUI (default)
 - **Testing only**: GUI can be disabled with `--no-gui` or `HEADLESS=1` for automated testing
 
-> **Note**: AppImages from v2025.08.22.4+ include the Avalonia double initialization fix, smoke test timeout fix, and all necessary native dependencies (libSkiaSharp, libHarfBuzzSharp) for proper GUI functionality. Earlier versions may experience GUI initialization issues or CI test timeouts.
+> **Note**: AppImages from v2025.08.22.4+ included fixes specific to the previous Avalonia-based UI. The project now uses GTK4 for native Wayland support and true click-through overlays. Older AppImages may still reference Avalonia-related fixes, but current builds ship with GTK4 and Wayland-first behavior.
 
 ### System Requirements
 - **Target Platform**: Fedora Linux with Wayland (GNOME)
-- **Current GUI Framework**: Avalonia UI (cross-platform)
-- **Click-Through Limitation**: Overlays are transparent but not fully click-through on native Wayland
+- **Current GUI Framework**: GTK4 (Wayland-first; optional gtk-layer-shell when available)
+- **Click-Through**: True compositor-level click-through on Wayland by clearing the input region on the Gdk surface. Falls back to a fullscreen toplevel when layer-shell is unavailable.
 - **Recommended tools**: grim (Wayland), gnome-screenshot/spectacle; scrot/maim (X11 fallback)
 - **Clipboard**: wl-clipboard (wl-copy/wl-paste) recommended; xclip as X11 fallback
 
-### Known Limitations
-- **Overlay Click-Through**: Current Avalonia implementation provides visual transparency but limited click-through on Wayland
-- **Workaround**: Run under XWayland for better click-through support
-- **Future**: Migration to GTK4 planned for native Wayland click-through support
+### Notes on Wayland Support
+- Overlays use GTK4 and attempt gtk-layer-shell for robust z-ordering and per-monitor placement.
+- When layer-shell is active, the overlay is anchored to all edges on the selected monitor with no exclusive zone and no keyboard focus.
+- Pointer events are passed through by disabling the surface input region, enabling click-through on supported compositors (GNOME, KDE, wlroots-based).
+- Coordinate semantics: under layer-shell, drawing is monitor-relative; tools pre-adjust coordinates accordingly.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ You can also check for updates directly from the application's **Settings tab** 
 - **Recommended tools**: grim (Wayland), gnome-screenshot/spectacle; scrot/maim (X11 fallback)
 - **Clipboard**: wl-clipboard (wl-copy/wl-paste) recommended; xclip as X11 fallback
 
-### Notes on Wayland Support
-- Overlays use GTK4 and attempt gtk-layer-shell for robust z-ordering and per-monitor placement.
-- When layer-shell is active, the overlay is anchored to all edges on the selected monitor with no exclusive zone and no keyboard focus.
-- Pointer events are passed through by disabling the surface input region, enabling click-through on supported compositors (GNOME, KDE, wlroots-based).
-- Coordinate semantics: under layer-shell, drawing is monitor-relative; tools pre-adjust coordinates accordingly.
+### Notes on Web‑First Architecture
+- Preferred path is a self-hosted web app: browser renders overlays above a remote desktop viewer (Apache Guacamole) with CSS pointer-events: none, guaranteeing click‑through on all platforms.
+- Initial multi-monitor experience uses two Firefox tabs/windows, each fullscreen on a physical monitor and cropped to its viewport of a single large RDP desktop.
+- MCP server remains in C# over HTTP and broadcasts overlay commands to the browser via WebSocket.
+- Podman (rootless) is preferred for all OCI containers; OpenTofu modules provision infra, VMs (Fedora Silverblue with xrdp), and TLS/DNS.
+- We favor open‑source components (Caddy, Guacamole, Postgres, Fedora).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,64 +1,68 @@
-# overlay-companion-mcp
+# Overlay Companion MCP (Web‑first)
 
-[![MCP](https://img.shields.io/badge/MCP-Model%20Context%20Protocol-FF6B35?style=for-the-badge&logo=anthropic)](https://modelcontextprotocol.io/)
-[![Platform](https://img.shields.io/badge/platform-Linux%20AppImage-FCC624?style=for-the-badge&logo=linux)](https://appimage.org/)
-[![Language](https://img.shields.io/badge/language-C%23-239120?style=for-the-badge&logo=csharp)](https://docs.microsoft.com/en-us/dotnet/csharp/)
-[![AI](https://img.shields.io/badge/AI-Cherry%20Studio%20Compatible-4285F4?style=for-the-badge&logo=openai)](https://cherry-studio.ai/)
-[![Automation](https://img.shields.io/badge/automation-Human%20in%20Loop-28A745?style=for-the-badge&logo=robot)](https://github.com/RyansOpenSauceRice/overlay-companion-mcp)
-[![Status](https://img.shields.io/badge/status-development-yellow?style=for-the-badge&logo=github)](https://github.com/RyansOpenSauceRice/overlay-companion-mcp)
-[![License](https://img.shields.io/badge/license-GPL--3.0-blue?style=for-the-badge)](https://www.gnu.org/licenses/gpl-3.0.html)
-[![Docs](https://img.shields.io/badge/docs-specification-green?style=for-the-badge&logo=markdown)](https://github.com/RyansOpenSauceRice/overlay-companion-mcp/blob/main/SPECIFICATION.md)
+A browser‑first, human‑in‑the‑loop screen interaction system. The MCP server (C#/.NET) broadcasts overlay events over WebSockets, and a browser client renders them in a guaranteed click‑through layer (CSS pointer‑events: none). Native GTK4 overlays remain as an optional local path; the default UX is web.
 
-A general-purpose, human-in-the-loop AI-assisted screen interaction toolkit built with the **official ModelContextProtocol C# SDK**.
+- Protocol: Model Context Protocol (MCP) over HTTP
+- Server: ASP.NET Core with /mcp (MCP), /ws/overlays (WebSocket), and a static viewer at /
+- Viewer: Static HTML/JS overlay layer; planned integration with Apache Guacamole for remote desktop
+- Infra preference: Podman (rootless), OpenTofu; target desktop VM: Fedora Silverblue with xrdp; OSS stack (Caddy, Guacamole, Postgres)
 
-## Installation
+## Why the pivot to web‑first
+- Guaranteed click‑through using CSS instead of compositor‑specific tricks
+- Multi‑monitor with no native windowing hacks: open multiple browser windows cropped to viewports
+- Works the same locally and over remote desktop (Guacamole)
 
-### Download AppImage (Recommended)
-1. Download the latest AppImage from [Releases](https://github.com/RyansOpenSauceRice/overlay-companion-mcp/releases)
-2. Make it executable: `chmod +x overlay-companion-mcp-*.AppImage`
-3. Run: `./overlay-companion-mcp-*.AppImage`
+## Architecture
+Components
+- MCP Server (C#/.NET)
+  - /mcp: HTTP transport for MCP
+  - /ws/overlays: WebSocket fan‑out of overlay events
+  - /: Static viewer (stub) that draws overlays
+- OverlayEventBroadcaster
+  - In‑memory registry of WS clients; broadcasts create/remove/clear events
+- Browser Viewer (stub)
+  - Absolutely positioned overlay layer with pointer‑events: none
+  - Viewport cropping via URL params: vx, vy, vw, vh, scale
+  - Draws boxes from WS messages; clicks go to the canvas behind (or Guacamole in future)
+- Remote Desktop (planned)
+  - Apache Guacamole embeds a FreeRDP canvas; overlay sits above it in the DOM
 
-#### Automatic Updates
-The AppImage supports automatic updates via AppImageUpdate:
+Data flow
+1) An MCP tool (e.g., draw_overlay) is invoked
+2) Server updates internal state and broadcasts overlay events over /ws/overlays
+3) Browser viewer renders the boxes in a click‑through overlay layer
 
-1. **Install AppImageUpdate**: `sudo apt install appimageupdate` or download from [AppImageUpdate releases](https://github.com/AppImage/AppImageUpdate/releases)
-2. **Check for updates**: `appimageupdate --check-for-update overlay-companion-mcp-*.AppImage`
-3. **Update automatically**: `appimageupdate overlay-companion-mcp-*.AppImage`
+Notes on native overlays
+- GTK4 overlay windows are still supported for local sessions. On Wayland we attempt gtk‑layer‑shell; we clear the input region for pass‑through. The web path is the primary experience going forward.
 
-You can also check for updates directly from the application's **Settings tab** when running as an AppImage. The app will automatically detect if it's running as an AppImage and show update controls.
+## Quick start
+Prereqs: .NET 8 SDK to build from source; any modern browser for the viewer.
 
-**Architecture**: The application runs an **HTTP server** (required for MCP protocol) with a **GUI interface**:
-- **Normal operation**: HTTP server + GUI (default)
-- **Testing only**: GUI can be disabled with `--no-gui` or `HEADLESS=1` for automated testing
+- Run the server (dev):
+  - dotnet run from src/ (or run the published binary/AppImage)
+- Open the viewer:
+  - http://localhost:3000/
+- Create a test overlay:
+  - From the GTK UI: Overlay tab -> Test Click‑Through Overlay
+  - Or via tools from your MCP client (draw_overlay)
+- Multi‑monitor demo:
+  - Open two browser windows full‑screen on two physical monitors
+  - Use viewport params, e.g. /?vx=0&vy=0&vw=1920&vh=1080 and /?vx=1920&vy=0&vw=1920&vh=1080
 
-> **Note**: AppImages from v2025.08.22.4+ included fixes specific to the previous Avalonia-based UI. The project now uses GTK4 for native Wayland support and true click-through overlays. Older AppImages may still reference Avalonia-related fixes, but current builds ship with GTK4 and Wayland-first behavior.
+Endpoints
+- /mcp: MCP HTTP transport
+- /ws/overlays: WebSocket stream of overlay events
+- /: Static overlay viewer (stub)
+- /setup and /config: Convenience configuration endpoints
 
-### System Requirements
-- **Target Platform**: Fedora Linux with Wayland (GNOME)
-- **Current GUI Framework**: GTK4 (Wayland-first; optional gtk-layer-shell when available)
-- **Click-Through**: True compositor-level click-through on Wayland by clearing the input region on the Gdk surface. Falls back to a fullscreen toplevel when layer-shell is unavailable.
-- **Recommended tools**: grim (Wayland), gnome-screenshot/spectacle; scrot/maim (X11 fallback)
-- **Clipboard**: wl-clipboard (wl-copy/wl-paste) recommended; xclip as X11 fallback
-
-### Notes on Web‑First Architecture
-- Preferred path is a self-hosted web app: browser renders overlays above a remote desktop viewer (Apache Guacamole) with CSS pointer-events: none, guaranteeing click‑through on all platforms.
-- Initial multi-monitor experience uses two Firefox tabs/windows, each fullscreen on a physical monitor and cropped to its viewport of a single large RDP desktop.
-- MCP server remains in C# over HTTP and broadcasts overlay commands to the browser via WebSocket.
-- Podman (rootless) is preferred for all OCI containers; OpenTofu modules provision infra, VMs (Fedora Silverblue with xrdp), and TLS/DNS.
-- We favor open‑source components (Caddy, Guacamole, Postgres, Fedora).
-
-## Usage
-
-### MCP Integration
-Configure with Cherry Studio or other MCP-compatible AI clients using HTTP transport (recommended):
-
+## MCP configuration example (HTTP transport)
 ```json
 {
   "mcpServers": {
     "overlay_companion": {
       "url": "http://localhost:3000/mcp",
-      "description": "AI-assisted screen interaction with overlay functionality for multi-monitor setups",
-      "tags": ["screen-capture", "overlay", "automation", "multi-monitor", "gtk4", "linux"],
+      "description": "Web‑first click‑through overlays with multi‑monitor via browser viewports",
+      "tags": ["overlay", "click-through", "browser", "multi-monitor", "websocket"],
       "provider": "Overlay Companion",
       "provider_url": "https://github.com/RyansOpenSauceRice/overlay-companion-mcp"
     }
@@ -66,115 +70,23 @@ Configure with Cherry Studio or other MCP-compatible AI clients using HTTP trans
 }
 ```
 
-**Legacy STDIO transport** (deprecated, use only if HTTP is not supported):
-```json
-{
-  "mcpServers": {
-    "overlay-companion": {
-      "command": "/path/to/overlay-companion-mcp",
-      "args": ["--stdio"]
-    }
-  }
-}
-```
+Legacy stdio is available with --stdio, but HTTP is the default and recommended.
 
-### Easy Configuration Setup
-
-For a better user experience, the application provides configuration endpoints when running:
-
-- **Web UI**: Visit `http://localhost:3000/setup` for an interactive configuration interface
-- **JSON Config**: Get ready-to-use configuration from `http://localhost:3000/config`
-- **Copy & Paste**: One-click copy functionality for easy setup in Cherry Studio
-
-The configuration includes proper metadata (description, tags, provider info) for better integration with MCP clients.
-
-### Available Tools
-- Screen capture, overlays, multi-monitor info
-- Input simulation and clipboard tools
-- Human-in-the-loop confirmations
-
-Note: Wayland is preferred with X11 fallback. See SPECIFICATION.md for platform integration details.
-
-For complete tool documentation, see [MCP_SPECIFICATION.md](MCP_SPECIFICATION.md).
+## System notes
+- Viewer runs anywhere a browser runs; overlays are click‑through by design
+- Server currently targets Linux; Fedora Silverblue Wayland is the reference environment
+- AppImage builds are supported; in‑app update controls appear when running as AppImage (details moved to docs)
 
 ## Development
+- Server: C#/.NET, ASP.NET Core
+- Web client: static HTML/JS (no build step); replace with Guacamole integration in future
+- Run server on port 3000; open the viewer at /
 
-**Contributors and AI agents:** See [DEVELOPMENT_SETUP.md](docs/DEVELOPMENT_SETUP.md) for development environment setup.
+## Roadmap (short)
+- Replace stub viewer with Guacamole RDP canvas
+- Initial WS sync for late‑joining viewers
+- Playwright E2E for overlay draw, click‑through, and multi‑window sync
+- Infra modules (Podman/OpenTofu) and Web UI for user‑facing configuration
 
-## Troubleshooting
-
-### AppImage Issues
-
-#### "Setup was already called on one of AppBuilder instances" Error
-
-**Fixed in v2025.08.22.2+**: This Avalonia double initialization error has been resolved with proper lifetime management.
-
-**Symptoms:**
-- HTTP server starts successfully on port 3000
-- Error occurs during GUI initialization
-- Application crashes with Avalonia setup error
-
-**Solution:**
-- **Update to latest AppImage** (v2025.08.22.4 or newer)
-- For older versions, temporary workaround: `HEADLESS=1 ./overlay-companion-mcp.AppImage` (testing mode only)
-
-#### GUI Not Starting
-
-**Desktop Environment:**
-- Ensure you're running in a desktop environment (GNOME, KDE, XFCE, etc.)
-- Check that `$DISPLAY` is set (X11) or Wayland compositor is running
-- Try: `./overlay-companion-mcp.AppImage --gui` to force GUI mode
-
-**Headless Environment:**
-- Use `HEADLESS=1` environment variable or `--no-gui` flag
-- HTTP transport will work without GUI: `http://localhost:3000/mcp`
-
-#### Native Library Issues
-
-**libSkiaSharp/libHarfBuzzSharp errors:**
-- Update to AppImage v2025.08.22.4+ (includes all native dependencies and fixes)
-- For manual builds, ensure native libraries are in LD_LIBRARY_PATH
-
-### Transport Issues
-
-#### HTTP Transport (Recommended)
-- Default port: 3000
-- Check firewall settings if connection fails
-- Use `netstat -tlnp | grep 3000` to verify server is listening
-
-#### STDIO Transport (Deprecated)
-- Use `--stdio` flag for legacy compatibility
-- Ensure MCP client supports STDIO transport
-- Consider migrating to HTTP transport for better features
-
-## Documentation Quality
-
-This repository maintains high documentation standards with automated quality checks:
-
-### Markdown Linting
-
-All markdown files are automatically checked for:
-- **Style consistency** using markdownlint
-- **Spelling accuracy** using cspell
-- **Link validity** using markdown-link-check
-- **Table of contents** synchronization
-
-### Running Checks Locally
-
-```bash
-# Run all markdown quality checks
-./scripts/lint-markdown.sh
-
-# Or run individual tools
-markdownlint "**/*.md"
-cspell "**/*.md"
-```
-
-### GitHub Actions
-
-Quality checks run automatically on:
-- All pull requests
-- Pushes to main/develop branches
-- Changes to markdown files
-
-See `.github/workflows/` for complete automation setup.
+## License
+GPL‑3.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,27 +25,19 @@
 
 ## 🚀 **HIGH PRIORITY - Missing Core Features**
 
-### 1. **Multi-Monitor Support** 🖥️🖥️
-**Status**: Planned but not implemented  
-**Impact**: Critical for professional/enterprise use  
-**Current Limitation**: All operations assume single monitor (index 0)
+### 1. **Multi-Monitor (Web) – Two Firefox Tabs** 🖥️🖥️
+**Status**: Implement as web feature  
+**Impact**: Critical  
+**Initial Behavior**: One RDP desktop spanning two monitors; two Firefox tabs/windows opened by the launcher, each fullscreen on a physical monitor and cropped to its viewport.
 
 **Implementation Needed**:
-- **`get_display_info` tool**: Return monitor count, resolutions, positions, primary monitor
-- **Enhanced `CaptureMonitorAsync`**: Proper multi-monitor screenshot capture
-- **Monitor-aware overlays**: Coordinate mapping across multiple displays
-- **Display detection**: Runtime discovery of monitor configuration changes
-
-**Technical Details**:
-```csharp
-// Current TODO in ScreenCaptureService.cs:
-MonitorIndex = 0, // TODO: Implement multi-monitor detection
-// TODO: Implement proper multi-monitor support
-```
+- **Viewport model**: per-window rect {vx,vy,w,h}, devicePixelRatio, scale
+- **Coordinate translation**: render at (x - vx, y - vy) * scale; only draw if intersects
+- **Sync overlays**: BroadcastChannel/shared worker to synchronize overlays across windows
+- **Guacamole token bootstrap**: one RDP session shared by both tabs
 
 **Use Cases**:
 - Developers with multiple monitors
-- Trading/financial applications
 - Design/creative workflows
 - Enterprise environments
 
@@ -59,30 +51,21 @@ MonitorIndex = 0, // TODO: Implement multi-monitor detection
 
 **Current**: 13/15 documented tools implemented
 
-### 3. **HTTP Transport Enhancement** 🌐
-**Status**: Bridge implementation exists, needs proper HTTP transport  
-**Impact**: Future-proofing and web integration
+### 3. **HTTP Transport Enhancement (Native)** 🌐
+**Status**: Ensure native HTTP transport (ModelContextProtocol.AspNetCore)  
+**Impact**: Web integration, Playwright testing
 
-**Current Implementation**: HTTP-to-STDIO bridge (functional but not optimal)
-**Needed**: Native HTTP transport using `ModelContextProtocol.AspNetCore`
-
-**Benefits of HTTP Transport**:
-- **Multi-client support**: Multiple MCP clients can connect simultaneously
-- **Web integration**: Browser-based MCP clients can connect directly
-- **Session management**: Persistent connections and state
-- **Streaming responses**: Large image data can be streamed efficiently
-- **Authentication**: Built-in auth support for secure deployments
-- **CORS support**: Cross-origin requests for web applications
+**Benefits**:
+- Multi-client support, streaming, CORS, session management
+- Direct compatibility with web overlay client via WebSocket bridge
 
 **Implementation Plan**:
 ```csharp
-// Use ModelContextProtocol.AspNetCore for native HTTP
 builder.Services
     .AddMcpServer()
-    .WithHttpTransport()  // Native HTTP, not bridge
+    .WithHttpTransport()
     .WithToolsFromAssembly();
-
-app.MapMcp();  // Registers /mcp endpoint with streaming support
+app.MapMcp();
 ```
 
 ---

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,61 +1,42 @@
-# Overlay Companion (MCP) - Tool Specification
+# Overlay Companion (MCP) – Web‑first Specification
 
-_A general-purpose, human-in-the-loop AI-assisted screen interaction toolkit._
-
----
-
-## Architecture Overview
-
-The Overlay Companion MCP server is built using the **official ModelContextProtocol C# SDK** from
-Microsoft/Anthropic, providing a robust foundation for MCP compliance and integration with the .NET
-ecosystem.
-
-### Deployment Architecture (Web‑First)
-
-The reference deployment is a self‑hosted web application with remote desktop viewing and browser‑rendered overlays. All user‑visible configuration is performed in a Web UI; OpenTofu and Podman provision and orchestrate services and VMs under the hood.
-
-```
-AI Client (Cherry Studio) → HTTP → MCP Server (C#) ⇄ WebSocket → Browser Overlay App
-                                              ↘ Reverse Proxy (Caddy) → Apache Guacamole → guacd → RDP → Fedora Silverblue VM (xrdp)
-```
-
-- **Use Case**: Fast iteration, deterministic click‑through, multi‑monitor
-- **Security**: TLS at the proxy; OIDC or local auth for Guacamole; per‑session JWTs for overlay channels
-- **Features**: Playwright‑testable in headless runners; web‑based multi‑window
-- **Orchestration**: Podman (rootless) for all OCI containers; OpenTofu modules for infra/VMs/DNS/TLS
-- **Preference**: Open‑source components wherever possible (Caddy, Guacamole, Postgres, Fedora Silverblue)
-
-#### Legacy STDIO Transport (Deprecated)
-
-```text
-Cherry Studio → stdio → MCP Server (OverlayCompanion)
-```
-
-- **Use Case**: Legacy compatibility only
-- **Limitations**: No image support, single client, deprecated
-- **Security**: Process-level isolation
-- **Command**: `dotnet run --stdio` (not recommended)
-
-### HTTP Transport Benefits
-
-The native HTTP transport provides critical advantages for modern MCP deployments:
-
-1. **Image Support**: Native handling of images and binary data (STDIO cannot handle images)
-2. **Multi-Client Support**: Multiple AI clients can connect simultaneously
-3. **Web Integration**: Direct browser access and web-based tooling
-4. **Streaming**: Server-Sent Events for real-time updates
-5. **Remote Deployment**: MCP server can run on different machines/containers
-6. **Monitoring**: HTTP traffic can be logged, monitored, and audited
-7. **Load Balancing**: Multiple MCP server instances with standard HTTP load balancers
-8. **CORS Support**: Cross-origin requests for web applications
+This specification defines the browser‑first architecture for Overlay Companion. The MCP server (C#/.NET) exposes an HTTP transport and broadcasts overlay events over WebSockets to a browser viewer that renders a guaranteed click‑through layer (CSS `pointer-events: none`). Native GTK4 overlays remain available for local sessions, but the default UX is the web viewer.
 
 ---
 
+## 1) Architecture
+
+Reference deployment (self‑hosted, OSS‑first):
+
+```
+AI Client (Cherry Studio) ──HTTP──▶ MCP Server (C#/.NET, ASP.NET Core)
+                                     │
+                                     ├──WebSocket (/ws/overlays) ──▶ Browser Overlay Viewer (HTML/JS)
+                                     │                                  ├─ Overlay layer (pointer-events: none)
+                                     │                                  └─ Viewport cropping (vx, vy, vw, vh, scale)
+                                     │
+                                     └──Reverse Proxy (Caddy) ──▶ Apache Guacamole ──▶ guacd ──▶ RDP ──▶ Fedora Silverblue VM (xrdp)
+```
+
+- Orchestration: Podman (rootless) containers, provisioned by OpenTofu modules
+- Datastore: Postgres for Guacamole (and future session state)
+- Target desktop: Fedora Silverblue (Wayland) with xrdp inside a VM, single large RDP desktop spanning monitors
+- Multi‑monitor MVP: Two browser windows, each full‑screen on a physical display and cropped to its viewport of the RDP desktop
+
+Legacy STDIO transport exists for compatibility, but HTTP is the default and recommended.
+
 ---
 
-## Browser Overlay Protocol (WebSocket) and Viewer Params
+## 2) Server Endpoints
 
-The server broadcasts overlay events to connected browsers via `/ws/overlays`.
+- GET /mcp: MCP over HTTP (official SDK)
+- GET /ws/overlays: WebSocket broadcast of overlay events (fan‑out to all connected viewers)
+- GET /: Static overlay viewer (stub)
+- GET /setup, GET /config: Convenience configuration endpoints
+
+---
+
+## 3) Browser Overlay Protocol (WebSocket)
 
 Message types
 - overlay_created
@@ -85,20 +66,36 @@ Viewer URL parameters (cropping for multi‑monitor)
 - vw, vh: viewport size
 - scale: client‑side scaling factor
 
-The viewer renders an absolutely positioned overlay layer with `pointer-events: none` so all clicks go through to the underlying canvas (Guacamole in future) or page content.
+The overlay layer is absolutely positioned with `pointer-events: none`, so all user input passes through to the underlying viewer (e.g., Guacamole canvas).
 
+---
 
-## MCP Tool Specification (JSON Format)
+## 4) Tool Surface (summary)
 
+The MCP toolset focuses on overlays, screenshots, and light input/sessions. Canonical, machine‑readable definitions live in MCP_SPECIFICATION.md. Key tools and notable parameters:
+
+- draw_overlay (async)
+  - x, y, width, height (px)
+  - color (name or hex), opacity (0..1, default 0.5)
+  - label (optional text), temporary_ms
+  - click_through (bool, default true)
+  - monitor_index (int, optional)
+- remove_overlay (sync): overlay_id
+- clear_overlays (sync): removes all overlays
+- batch_overlay (async): array of overlay specs; optional one_at_a_time
+- take_screenshot (async): region/full_screen, scale, wait_for_stable_ms
+- get_display_info (sync): monitor geometry for viewport planning
+- click_at / type_text (sync/async): kept but typically mediated by human confirmation in assist/autopilot modes
+
+Minimal JSON (abbreviated)
 ```json
 {
   "mcp_spec_version": "1.0",
   "name": "overlay-companion-mcp",
-  "description": "Public MCP server exposing overlay, screenshot, and input actions for human-in-the-loop UI automation.",
+  "description": "Web‑first overlays, screenshots, and input for human‑in‑the‑loop UI automation.",
   "tools": [
     {
       "id": "draw_overlay",
-      "title": "Draw overlay box",
       "mode": "async",
       "params": {
         "x": { "type": "number" },
@@ -106,180 +103,16 @@ The viewer renders an absolutely positioned overlay layer with `pointer-events: 
         "width": { "type": "number" },
         "height": { "type": "number" },
         "color": { "type": "string", "optional": true },
-        "opacity": { "type": "number", "optional": true, "description": "0.0 to 1.0 (default 0.5)" },
+        "opacity": { "type": "number", "optional": true },
         "label": { "type": "string", "optional": true },
-        "temporary_ms": { "type": "number", "optional": true }
+        "temporary_ms": { "type": "number", "optional": true },
+        "click_through": { "type": "boolean", "optional": true },
+        "monitor_index": { "type": "number", "optional": true }
       },
       "returns": {
         "overlay_id": "string",
         "bounds": { "x": "number", "y": "number", "width": "number", "height": "number" },
         "monitor_index": "number"
-      }
-    },
-    {
-      "id": "remove_overlay",
-      "title": "Remove overlay",
-      "mode": "sync",
-      "params": {
-        "overlay_id": { "type": "string" }
-      },
-      "returns": {
-        "removed": "boolean",
-        "not_found": "boolean"
-      }
-    },
-    {
-      "id": "take_screenshot",
-      "title": "Take screenshot",
-      "mode": "async",
-      "params": {
-        "region": { "type": "object", "optional": true },
-        "full_screen": { "type": "boolean", "optional": true },
-        "scale": { "type": "number", "optional": true },
-        "wait_for_stable_ms": { "type": "number", "optional": true }
-      },
-      "returns": {
-        "image_base64": "string",
-        "width": "number",
-        "height": "number",
-        "region": "object",
-        "monitor_index": "number",
-        "display_scale": "number",
-        "viewport_scroll": { "x": "number", "y": "number" }
-      }
-    },
-    {
-      "id": "click_at",
-      "title": "Simulate click",
-      "mode": "sync",
-      "params": {
-        "x": { "type": "number" },
-        "y": { "type": "number" },
-        "button": { "type": "string", "enum": ["left","right","middle"], "optional": true },
-        "clicks": { "type": "number", "optional": true },
-        "require_user_confirmation": { "type": "boolean", "optional": true },
-        "action_timing_hint": { "type": "object", "optional": true }
-      },
-      "returns": {
-        "success": "boolean",
-        "was_confirmed": "boolean"
-      }
-    },
-    {
-      "id": "type_text",
-      "title": "Emulate typing",
-      "mode": "async",
-      "params": {
-        "text": { "type": "string" },
-        "typing_speed_wpm": { "type": "number", "optional": true },
-        "require_user_confirmation": { "type": "boolean", "optional": true },
-        "action_timing_hint": { "type": "object", "optional": true }
-      },
-      "returns": {
-        "success": "boolean",
-        "typed_length": "number"
-      }
-    },
-    {
-      "id": "set_mode",
-      "title": "Set operational mode",
-      "mode": "sync",
-      "params": {
-        "mode": { "type": "string", "enum": ["passive","assist","autopilot","composing","custom"] },
-        "metadata": { "type": "object", "optional": true }
-      },
-      "returns": {
-        "ok": "boolean",
-        "active_mode": "string"
-      }
-    },
-    {
-      "id": "set_screenshot_frequency",
-      "title": "Set screenshot frequency",
-      "mode": "sync",
-      "params": {
-        "mode": { "type": "string" },
-        "interval_ms": { "type": "number" },
-        "only_on_change": { "type": "boolean", "optional": true }
-      },
-      "returns": {
-        "ok": "boolean",
-        "applied_interval_ms": "number"
-      }
-    },
-    {
-      "id": "get_clipboard",
-      "title": "Get clipboard",
-      "mode": "sync",
-      "params": {},
-      "returns": {
-        "text": "string",
-        "available": "boolean"
-      }
-    },
-    {
-      "id": "set_clipboard",
-      "title": "Set clipboard",
-      "mode": "sync",
-      "params": {
-        "text": { "type": "string" }
-      },
-      "returns": {
-        "ok": "boolean"
-      }
-    },
-    {
-      "id": "batch_overlay",
-      "title": "Draw multiple overlays",
-      "mode": "async",
-      "params": {
-        "overlays": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "x": { "type": "number" },
-              "y": { "type": "number" },
-              "width": { "type": "number" },
-              "height": { "type": "number" },
-              "color": { "type": "string", "optional": true },
-              "opacity": { "type": "number", "optional": true, "description": "0.0 to 1.0 (default 0.5)" },
-              "label": { "type": "string", "optional": true },
-              "temporary_ms": { "type": "number", "optional": true },
-              "click_through": { "type": "boolean", "optional": true },
-              "monitor_index": { "type": "number", "optional": true }
-            }
-          }
-        },
-        "one_at_a_time": { "type": "boolean", "optional": true }
-      },
-      "returns": {
-        "overlay_ids": "array"
-      }
-    },
-    {
-      "id": "subscribe_events",
-      "title": "Subscribe to UI events",
-      "mode": "async",
-      "params": {
-        "events": { "type": "array", "items": { "type": "string" } },
-        "debounce_ms": { "type": "number", "optional": true },
-        "filter": { "type": "object", "optional": true }
-      },
-      "returns": {
-        "subscription_id": "string",
-        "subscribed": "array"
-      }
-    },
-    {
-      "id": "unsubscribe_events",
-      "title": "Unsubscribe from events",
-      "mode": "sync",
-      "params": {
-        "subscription_id": { "type": "string" }
-      },
-      "returns": {
-        "ok": "boolean"
       }
     }
   ]
@@ -288,457 +121,38 @@ The viewer renders an absolutely positioned overlay layer with `pointer-events: 
 
 ---
 
-## Detailed Tool Descriptions
+## 5) Security Model
 
-### 1. draw_overlay
-
-**Purpose**: Draw a visual overlay box on the screen for highlighting or annotation.
-
-**Parameters**:
-
-- `x` (number, required): X coordinate in screen pixels
-- `y` (number, required): Y coordinate in screen pixels
-- `width` (number, required): Width of overlay in pixels
-- `height` (number, required): Height of overlay in pixels
-- `color` (string, optional): Color name or hex code (default: "red")
-- `label` (string, optional): Text label to display on overlay
-- `temporary_ms` (number, optional): Auto-remove after milliseconds
-
-**Returns**:
-
-- `overlay_id`: Unique identifier for the created overlay
-- `bounds`: Actual bounds of the overlay (may be adjusted for screen boundaries)
-- `monitor_index`: Index of the monitor where overlay was placed
-
-**Example**:
-
-```json
-{
-  "method": "draw_overlay",
-  "params": {
-    "x": 100,
-    "y": 200,
-    "width": 300,
-    "height": 50,
-    "color": "blue",
-    "label": "Click here",
-    "temporary_ms": 5000
-  }
-}
-```
-
-### 2. remove_overlay
-
-**Purpose**: Remove a previously created overlay by its ID.
-
-**Parameters**:
-
-- `overlay_id` (string, required): ID of overlay to remove
-
-**Returns**:
-
-- `removed`: True if overlay was successfully removed
-- `not_found`: True if overlay ID was not found
-
-### 3. take_screenshot
-
-**Purpose**: Capture a screenshot of the screen or a specific region.
-
-**Parameters**:
-- `region` (object, optional): Specific region to capture `{x, y, width, height}`
-- `full_screen` (boolean, optional): Capture entire screen (default: true)
-- `scale` (number, optional): Scale factor for image (default: 1.0)
-- `wait_for_stable_ms` (number, optional): Wait for UI to stabilize before capture
-
-**Returns**:
-- `image_base64`: Base64-encoded PNG image data
-- `width`: Image width in pixels
-- `height`: Image height in pixels
-- `region`: Actual captured region
-- `monitor_index`: Monitor that was captured
-- `display_scale`: Display scaling factor
-- `viewport_scroll`: Current scroll position if applicable
-
-### 4. click_at
-
-**Purpose**: Simulate a mouse click at specified coordinates.
-
-**Parameters**:
-- `x` (number, required): X coordinate to click
-- `y` (number, required): Y coordinate to click
-- `button` (string, optional): Mouse button ("left", "right", "middle", default: "left")
-- `clicks` (number, optional): Number of clicks (default: 1)
-- `require_user_confirmation` (boolean, optional): Require user confirmation
-- `action_timing_hint` (object, optional): Timing hints for the action
-
-**Returns**:
-- `success`: True if click was executed successfully
-- `was_confirmed`: True if user confirmation was required and given
-
-### 5. type_text
-
-**Purpose**: Simulate keyboard typing of text.
-
-**Parameters**:
-- `text` (string, required): Text to type
-- `typing_speed_wpm` (number, optional): Typing speed in words per minute (default: 60)
-- `require_user_confirmation` (boolean, optional): Require user confirmation
-- `action_timing_hint` (object, optional): Timing hints for the action
-
-**Returns**:
-- `success`: True if typing was executed successfully
-- `typed_length`: Number of characters actually typed
-
-### 6. set_mode
-
-**Purpose**: Set the operational mode of the system.
-
-**Parameters**:
-- `mode` (string, required): Mode name ("passive", "assist", "autopilot", "composing", "custom")
-- `metadata` (object, optional): Additional mode-specific configuration
-
-**Returns**:
-- `ok`: True if mode was set successfully
-- `active_mode`: Currently active mode name
-
-**Modes**:
-- **passive**: Read-only operations (screenshots, overlays)
-- **assist**: Suggests actions, requires confirmation
-- **autopilot**: Automated actions with safety checks
-- **composing**: Specialized for text composition
-- **custom**: User-defined behavior
-
-### 7. set_screenshot_frequency
-
-**Purpose**: Configure automatic screenshot capture frequency.
-
-**Parameters**:
-- `mode` (string, required): Frequency mode ("manual", "periodic", "on_change")
-- `interval_ms` (number, required): Interval in milliseconds
-- `only_on_change` (boolean, optional): Only capture when screen changes
-
-**Returns**:
-- `ok`: True if frequency was set successfully
-- `applied_interval_ms`: Actual interval applied (may be rate-limited)
-
-### 8. get_clipboard
-
-**Purpose**: Get the current clipboard content.
-
-**Parameters**: None
-
-**Returns**:
-- `text`: Current clipboard text content
-- `available`: True if clipboard content is available
-
-### 9. set_clipboard
-
-**Purpose**: Set the clipboard content.
-
-**Parameters**:
-- `text` (string, required): Text to set in clipboard
-
-**Returns**:
-- `ok`: True if clipboard was set successfully
-
-### 10. batch_overlay
-
-**Purpose**: Create multiple overlays in a single operation.
-
-**Parameters**:
-- `overlays` (array, required): Array of overlay specifications
-- `one_at_a_time` (boolean, optional): Create overlays sequentially vs. simultaneously
-
-**Returns**:
-- `overlay_ids`: Array of created overlay IDs
-
-### 11. subscribe_events
-
-**Purpose**: Subscribe to UI events for monitoring.
-
-**Parameters**:
-- `events` (array, required): Array of event types to subscribe to
-- `debounce_ms` (number, optional): Debounce interval for events
-- `filter` (object, optional): Event filter criteria
-
-**Event Types**:
-- `mouse_move`: Mouse movement events
-- `mouse_click`: Mouse click events
-- `key_press`: Keyboard events
-- `window_focus`: Window focus changes
-- `screen_change`: Screen content changes
-
-**Returns**:
-- `subscription_id`: Unique subscription identifier
-- `subscribed`: Array of successfully subscribed event types
-
-### 12. unsubscribe_events
-
-**Purpose**: Unsubscribe from previously subscribed events.
-
-**Parameters**:
-- `subscription_id` (string, required): Subscription ID to cancel
-
-**Returns**:
-- `ok`: True if unsubscription was successful
+- TLS termination at Caddy; CORS configured for the web app
+- Authentication/authorization handled at the proxy and Guacamole (OIDC or local); per‑viewer JWTs for overlay WS are planned
+- No long‑term storage of screenshots by default; session data retention is configurable
+- Principle of least privilege: input simulation gated by modes and confirmations
 
 ---
 
-## Error Handling
+## 6) Implementation Roadmap (Web‑first)
 
-All tools return standard MCP error responses for:
+Short‑term
+- Replace stub viewer with Guacamole canvas; keep overlay layer above
+- Initial WS sync on connect and “request_sync” message type
+- Playwright E2E: draw, remove, clear, 2‑window viewport sync; click‑through verification
 
-- **Invalid parameters**: Missing or invalid parameter values
-- **Permission denied**: Operation not allowed in current mode
-- **System error**: Underlying system operation failed
-- **Rate limited**: Too many requests in time window
+Medium
+- Multi‑monitor window manager (launch/crop multiple viewers automatically)
+- Per‑session auth tokens for WS overlay channels
+- Server‑side overlay composition offscreen for recording/replay
 
----
-
-## Security & Safety
-
-### Human-in-the-Loop Controls
-
-- Input simulation requires confirmation in most modes
-- Mode-based permission system
-- Rate limiting on all operations
-- User override capabilities
-
-### Privacy Protection
-
-- All operations are local-only
-- Screenshot data can be scrubbed before sharing
-- Clipboard access requires explicit permission
-- No network communication
-
-### Platform Integration
-
-#### Web‑First (Preferred)
-- Remote desktop: Apache Guacamole (web app) + guacd + RDP via FreeRDP
-- Target OS: Fedora Silverblue VM (xrdp) with virtio‑gpu; single large desktop spanning 2 monitors initially
-- Browser overlays: HTML canvas/SVG above viewer with CSS pointer-events: none (guaranteed click‑through)
-- Multi‑monitor: two Firefox tabs/windows, each fullscreen on a monitor, cropping to its viewport; coordinate translation handled in JS
-
-#### Linux (Native) – Secondary path
-- Clipboard: wl-clipboard (wl-copy/wl-paste) preferred; fallback: xclip
-- Screenshots: grim (+ slurp) or gnome-screenshot/spectacle; fallback: scrot/maim
-- Display/monitors: swaymsg, hyprctl; fallback: xrandr, xdpyinfo
-- Note: Native OS overlays remain limited by compositor policy; web route avoids this entirely
-
-#### General
-- Respects system accessibility settings
-- Works with screen readers and assistive technology
-- Follows platform-specific UI guidelines
-- Handles multi-monitor setups correctly
+Later
+- Native wrapper/FreeRDP multimon for environments where browser is not available
 
 ---
 
-## Implementation Roadmap
+## 7) Versioning
 
-### High Priority (Core Functionality)
-
-- **Complete AvaloniaOverlayWindow rendering** - Make overlays actually visible
-- **Session Stop implementation** - Critical safety feature  
-- **Color and text rendering** - Basic overlay functionality
-
-### Medium Priority (Enhanced Features)
-
-- **GUI overlay management panel** - User control and monitoring
-- **Multi-monitor support** - Professional deployment requirement
-- **Advanced overlay shapes** - Enhanced AI interaction capabilities
-
-### Low Priority (Polish)
-
-- **Overlay animations** - Visual enhancement
-- **Interactive overlays** - Advanced interaction modes
-- **Overlay templates** - Predefined overlay styles
+Date‑based: YYYY.MM.DD[.N]
 
 ---
 
-## Versioning Schema
+## 8) Notes moved out of spec
 
-The project follows a **date-based versioning schema** for releases:
-
-### Format: `YYYY.MM.DD[.N]`
-
-- **YYYY**: 4-digit year
-- **MM**: 2-digit month (01-12)
-- **DD**: 2-digit day (01-31)
-- **N**: Optional build number for multiple releases in the same day (starting from 1)
-
-### Examples
-
-- `2024.08.18` - First release on August 18, 2024
-- `2024.08.18.1` - Second release on August 18, 2024
-- `2024.08.18.2` - Third release on August 18, 2024
-- `2024.12.25` - First release on December 25, 2024
-
-### Release Automation
-
-- **Automatic versioning**: GitHub Actions automatically calculate the next version
-- **Daily builds**: Each day gets a new base version
-- **Multiple builds**: Same-day builds increment the build number
-- **GitHub releases**: Automatically created with AppImage artifacts
-
----
-
-## GitHub Actions & CI/CD
-
-The project includes comprehensive automation through GitHub Actions:
-
-### 1. **Markdown Linting** (`markdown-lint.yml`)
-- **Purpose**: Documentation quality assurance
-- **Triggers**: Push/PR to main/develop branches (markdown files)
-- **Checks**:
-  - Markdown syntax and style consistency
-  - Spelling accuracy with cspell
-  - Link validity verification
-  - Table of contents synchronization
-- **Tools**: markdownlint-cli, cspell, markdown-link-check
-
-### 2. **C# Linting** (`csharp-lint.yml`)
-- **Purpose**: Code quality and build verification
-- **Triggers**: Push/PR to main/develop branches (C# files)
-- **Checks**:
-  - Code formatting verification (`dotnet format`)
-  - Build success validation
-  - Static analysis
-  - Security vulnerability scanning
-  - Deprecated package detection
-  - Code metrics analysis
-- **Artifacts**: Build outputs for verification
-
-### 3. **AppImage Build** (`build-appimage.yml`)
-- **Purpose**: Linux distribution package creation
-- **Triggers**:
-  - Push to main/develop (source changes)
-  - Manual workflow dispatch
-  - GitHub releases
-- **Features**:
-  - Automatic version calculation
-  - AppImage creation with proper metadata
-  - Desktop integration files
-  - Artifact upload and testing
-  - Automatic GitHub release creation
-- **Outputs**: Distributable AppImage files
-
-### 4. **CI/CD Pipeline** (`ci-cd.yml`)
-- **Purpose**: Comprehensive continuous integration and deployment
-- **Triggers**: Push/PR to main/develop, manual dispatch
-- **Stages**:
-  - **Quality Gates**: Deployment condition checks
-  - **Markdown Quality**: Documentation validation
-  - **C# Quality**: Code quality and build verification
-  - **Unit Tests**: Automated test execution (when available)
-  - **Integration Tests**: Application startup and MCP server testing
-  - **Security Scan**: Vulnerability scanning with Trivy
-  - **Build AppImage**: Production-ready package creation
-  - **Deploy**: Environment-specific deployment
-  - **Notify**: Status notifications
-- **Environments**: Staging and production deployment support
-
-### Workflow Dependencies
-
-```mermaid
-graph TD
-    A[Push/PR] --> B[Quality Gates]
-    A --> C[Markdown Quality]
-    A --> D[C# Quality]
-    
-    B --> E[Should Deploy?]
-    D --> F[Unit Tests]
-    D --> G[Integration Tests]
-    D --> H[Security Scan]
-    
-    E --> I[Build AppImage]
-    F --> I
-    G --> I
-    
-    I --> J[Deploy]
-    J --> K[Notify]
-```
-
-### Quality Standards
-
-- **Zero tolerance**: All quality checks must pass
-- **Security first**: Vulnerability scanning on every build
-- **Documentation**: Markdown quality enforced
-- **Code style**: Consistent formatting required
-- **Build verification**: Must compile without errors
-- **Testing**: Automated validation where possible
-
-### CI/CD Best Practices & Timeout Management
-
-Based on extensive optimization work, the project implements comprehensive timeout protection across all workflows:
-
-#### Multi-Layered Timeout Strategy
-
-1. **Job-Level Timeouts**: Every workflow job has `timeout-minutes` to prevent runaway processes
-2. **Step-Level Timeouts**: Critical build/test steps have individual timeout limits
-3. **Command-Level Timeouts**: Shell commands use `timeout` utility for granular control
-4. **Process-Level Timeouts**: Long-running processes have built-in timeout mechanisms
-
-#### Timeout Configuration by Workflow
-
-- **ci-cd.yml**: 5-20 minutes per job, with step-level timeouts for builds (10min) and tests (8min)
-- **csharp-lint.yml**: 20 minutes total, with granular timeouts for restore (5min), format (3min), build (10min)
-- **markdown-lint.yml**: 10 minutes per job, with timeouts for npm installs (3min) and checks (3-5min)
-- **python-lint.yml**: 25 minutes total, with dependency installation (8min) and analysis timeouts (3-8min)
-- **build-appimage.yml**: 5 minutes for main tests, 3 minutes for smoke tests, with 60s/30s/180s command timeouts
-- **merge-ready.yml**: 15 minutes total, with build (8min) and test (3min) step timeouts
-
-#### Error Classification & Recovery
-
-- **Timeout Detection**: Exit code 124 indicates timeout vs. critical failure
-- **Smart Continuation**: Non-critical timeouts allow workflow continuation
-- **Progress Indicators**: All long-running operations show time limits and progress
-- **Graceful Degradation**: Tests continue when possible, failing only on critical errors
-
-#### Resource Management
-
-- **GitHub Actions Efficiency**: Prevents 8+ minute hangs that waste CI/CD resources
-- **Parallel Execution**: Jobs run concurrently where dependencies allow
-- **Artifact Caching**: NuGet packages, npm modules, and build outputs cached appropriately
-- **Early Termination**: Fast-fail on critical errors, continue on warnings
-
-#### Monitoring & Observability
-
-- **Structured Logging**: Clear progress indicators with time limits
-- **Error Context**: Timeout vs. failure distinction in all error messages
-- **Performance Tracking**: Build and test duration monitoring
-- **Resource Usage**: Memory and CPU usage awareness in timeout settings
-
-This timeout strategy ensures reliable CI/CD execution while maximizing resource efficiency and providing clear feedback on build/test performance.
-
----
-
-## Packaging Artifacts & Ignored Paths
-
-To keep the repository clean and reproducible, packaging outputs are generated at build time and must not be committed.
-
-- The build system writes all packaging outputs under build/ (AppDir tree, AppImage file, publish/ outputs). These are ignored via .gitignore.
-- The desktop entry and AppStream metadata are generated by scripts/build-appimage.sh during the build:
-  - Desktop file path: AppDir/usr/share/applications/overlay-companion-mcp.desktop
-  - AppStream file path: AppDir/usr/share/metainfo/overlay-companion-mcp.appdata.xml
-  - Source of truth: Variables and heredoc content inside scripts/build-appimage.sh (APP_NAME, APP_DISPLAY_NAME, APP_DESCRIPTION, APP_CATEGORY, versioning, etc.).
-- If you need to edit metadata, update scripts/build-appimage.sh. Optionally, introduce checked-in templates (e.g., packaging/linux/overlay-companion-mcp.desktop.tmpl and packaging/linux/overlay-companion-mcp.appdata.xml.tmpl) and have the script copy them into AppDir at build time.
-- Trimming: Disabled by default in src/OverlayCompanion.csproj for stability with Avalonia/reflection. Do not pass /p:PublishTrimmed or TrimMode in workflows or scripts unless you explicitly re-enable trimming in the project.
-- AppImage build notes:
-  - The script auto-detects dotnet or installs SDK 8 locally via dotnet-install.sh if missing.
-  - FUSE-less environments are supported via the extraction-based fallback.
-  - You can set APP_VERSION=YYYY.MM.DD prior to running the script to control the output filename.
-
-This policy prevents accidental commits of generated binaries and ensures the build remains deterministic across environments.
-
----
-
-## AI GUI Tests (AllHands-only)
-
-Purpose: provide a simple, key-free GUI test harness that runs inside the AllHands cloud environment and is not tied to GitHub Actions.
-
-- Location: tests/ai-gui/
-- Runner: tests/ai-gui/run.sh (invokes setup, builds app, launches under Xvfb, runs harness)
-- Evidence: tests/ai-gui/artifacts/ (screenshots, logs, JSON summary)
-- No API keys: uses stdio MCP when available or performs visual smoke tests until MCP is fully wired
-- Not part of GitHub Actions by design; run manually in AllHands cloud
-
+This specification intentionally drops legacy content (Avalonia specifics, deep CI/CD mechanics, packaging minutiae). See docs/ for any remaining operational notes.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -51,6 +51,43 @@ The native HTTP transport provides critical advantages for modern MCP deployment
 
 ---
 
+---
+
+## Browser Overlay Protocol (WebSocket) and Viewer Params
+
+The server broadcasts overlay events to connected browsers via `/ws/overlays`.
+
+Message types
+- overlay_created
+- overlay_removed
+- clear_overlays
+- request_sync (planned)
+- sync_state (planned)
+
+Example payloads
+```json
+{ "type": "overlay_created", "overlay": {
+  "id": "d3f1...",
+  "x": 100, "y": 200, "width": 300, "height": 120,
+  "color": "#ffcc00", "opacity": 0.5,
+  "monitor_index": 0, "created_at": "2025-08-24T08:10:00Z"
+}}
+```
+```json
+{ "type": "overlay_removed", "overlay_id": "d3f1..." }
+```
+```json
+{ "type": "clear_overlays" }
+```
+
+Viewer URL parameters (cropping for multi‑monitor)
+- vx, vy: viewport origin (global desktop coordinates)
+- vw, vh: viewport size
+- scale: client‑side scaling factor
+
+The viewer renders an absolutely positioned overlay layer with `pointer-events: none` so all clicks go through to the underlying canvas (Guacamole in future) or page content.
+
+
 ## MCP Tool Specification (JSON Format)
 
 ```json

--- a/deploy/opentofu/envs/dev/main.tf
+++ b/deploy/opentofu/envs/dev/main.tf
@@ -1,0 +1,56 @@
+# OpenTofu dev environment (mock) – wires modules together and emits artifacts
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    local  = { source = "hashicorp/local" }
+    random = { source = "hashicorp/random" }
+  }
+}
+
+provider "local" {}
+provider "random" {}
+
+resource "random_password" "db" {
+  length  = 20
+  special = false
+}
+
+module "db" {
+  source   = "../../modules/db"
+  password = random_password.db.result
+}
+
+module "guacamole" {
+  source      = "../../modules/guacamole"
+  db_host     = "127.0.0.1"
+  db_password = random_password.db.result
+}
+
+module "overlay" {
+  source    = "../../modules/overlay-server"
+  image     = "ghcr.io/ryansopensaucerice/overlay-companion-mcp:latest"
+  host_port = 3000
+  env = {
+    HEADLESS = "1"
+  }
+}
+
+module "caddy" {
+  source        = "../../modules/reverse-proxy"
+  domain        = "overlay.local"
+  overlay_host  = "127.0.0.1"
+  overlay_port  = 3000
+  guacamole_host = "127.0.0.1"
+  guacamole_port = 8080
+}
+
+output "artifacts" {
+  value = {
+    db_compose       = module.db.compose_path
+    guac_compose     = module.guacamole.compose_path
+    overlay_compose  = module.overlay.compose_path
+    caddyfile        = module.caddy.caddyfile_path
+  }
+}

--- a/deploy/opentofu/modules/db/main.tf
+++ b/deploy/opentofu/modules/db/main.tf
@@ -1,0 +1,30 @@
+# OpenTofu module: Postgres for Guacamole (mock)
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers { local = { source = "hashicorp/local" } }
+}
+
+variable "host_port" { type = number default = 5432 }
+variable "user" { type = string default = "guac" }
+variable "password" { type = string }
+variable "db" { type = string default = "guacamole" }
+
+resource "local_file" "compose" {
+  filename = "${path.module}/generated/db-compose.yml"
+  content  = <<YAML
+version: '3.8'
+services:
+  db:
+    image: docker.io/library/postgres:16-alpine
+    network_mode: host
+    environment:
+      - POSTGRES_USER=${var.user}
+      - POSTGRES_PASSWORD=${var.password}
+      - POSTGRES_DB=${var.db}
+    ports:
+      - "${var.host_port}:5432"
+YAML
+}
+
+output "compose_path" { value = local_file.compose.filename }

--- a/deploy/opentofu/modules/guacamole/main.tf
+++ b/deploy/opentofu/modules/guacamole/main.tf
@@ -1,0 +1,37 @@
+# OpenTofu module: guacamole stack (mock)
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers { local = { source = "hashicorp/local" } }
+}
+
+variable "db_host" { type = string }
+variable "db_port" { type = number default = 5432 }
+variable "db_name" { type = string default = "guacamole" }
+variable "db_user" { type = string default = "guac" }
+variable "db_password" { type = string }
+variable "host_port" { type = number default = 8080 }
+
+resource "local_file" "compose" {
+  filename = "${path.module}/generated/guacamole-compose.yml"
+  content  = <<YAML
+version: '3.8'
+services:
+  guacd:
+    image: guacamole/guacd:1.5.5
+    network_mode: host
+  guacamole:
+    image: guacamole/guacamole:1.5.5
+    network_mode: host
+    environment:
+      - POSTGRESQL_HOSTNAME=${var.db_host}
+      - POSTGRESQL_DATABASE=${var.db_name}
+      - POSTGRESQL_USER=${var.db_user}
+      - POSTGRESQL_PASSWORD=${var.db_password}
+      - GUACD_HOSTNAME=127.0.0.1
+    ports:
+      - "${var.host_port}:8080"
+YAML
+}
+
+output "compose_path" { value = local_file.compose.filename }

--- a/deploy/opentofu/modules/network/main.tf
+++ b/deploy/opentofu/modules/network/main.tf
@@ -1,0 +1,8 @@
+# OpenTofu module: network (placeholder for DNS/TLS)
+
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+# In a real deployment this would manage DNS records, TLS certs, and firewall rules.
+# Left intentionally minimal as a placeholder.

--- a/deploy/opentofu/modules/overlay-server/main.tf
+++ b/deploy/opentofu/modules/overlay-server/main.tf
@@ -1,0 +1,38 @@
+# OpenTofu module: overlay-server
+# Purpose: runs the ASP.NET Core MCP overlay server and static viewer via Podman
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    local = { source = "hashicorp/local" }
+    random = { source = "hashicorp/random" }
+  }
+}
+
+variable "image" { type = string }
+variable "name"  { type = string  default = "overlay-server" }
+variable "host_port" { type = number default = 3000 }
+variable "env" {
+  type = map(string)
+  default = {}
+}
+
+# This is a mockup using local_file to emit a podman-compose file. In real infra
+# this module would apply via a podman provider or a remote runner.
+
+resource "local_file" "podman_compose" {
+  filename = "${path.module}/generated/${var.name}-compose.yml"
+  content  = <<YAML
+version: "3.8"
+services:
+  server:
+    image: ${var.image}
+    container_name: ${var.name}
+    network_mode: host
+    environment:
+$(join("\n", [for k,v in var.env : "      - ${k}=${v}"]))
+    command: ["/app/OverlayCompanion", "--http-port", "${var.host_port}"]
+YAML
+}
+
+output "compose_path" { value = local_file.podman_compose.filename }

--- a/deploy/opentofu/modules/reverse-proxy/main.tf
+++ b/deploy/opentofu/modules/reverse-proxy/main.tf
@@ -1,0 +1,33 @@
+# OpenTofu module: reverse-proxy (Caddy)
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers { local = { source = "hashicorp/local" } }
+}
+
+variable "domain" { type = string }
+variable "overlay_host" { type = string }
+variable "overlay_port" { type = number default = 3000 }
+variable "guacamole_host" { type = string }
+variable "guacamole_port" { type = number default = 8080 }
+
+resource "local_file" "caddyfile" {
+  filename = "${path.module}/generated/Caddyfile"
+  content  = <<CADDY
+{
+  email admin@example.com
+}
+
+${var.domain} {
+  reverse_proxy /mcp ${var.overlay_host}:${var.overlay_port}
+  reverse_proxy /ws/overlays ${var.overlay_host}:${var.overlay_port}
+  reverse_proxy / ${var.overlay_host}:${var.overlay_port}
+}
+
+guac.${var.domain} {
+  reverse_proxy ${var.guacamole_host}:${var.guacamole_port}
+}
+CADDY
+}
+
+output "caddyfile_path" { value = local_file.caddyfile.filename }

--- a/src/OverlayCompanion.csproj
+++ b/src/OverlayCompanion.csproj
@@ -40,6 +40,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Web/**/*.cs" />
+    <Content Include="wwwroot/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -171,6 +171,23 @@ public class Program
             await context.Response.SendFileAsync(Path.Combine(AppContext.BaseDirectory, "wwwroot", "index.html"));
         });
 
+	        // Simple test endpoint for CI/manual verification
+	        app.MapPost("/api/test-overlay", async (IOverlayService overlaySvc) =>
+	        {
+	            var bounds = new OverlayCompanion.Models.ScreenRegion(50, 50, 200, 120);
+	            var overlay = new OverlayCompanion.Models.OverlayElement
+	            {
+	                Bounds = bounds,
+	                Color = "#ff0000",
+	                Opacity = 0.4,
+	                Label = "test",
+	                TemporaryMs = 1500,
+	                ClickThrough = true
+	            };
+	            var id = await overlaySvc.DrawOverlayAsync(overlay);
+	            return Results.Json(new { ok = true, overlay_id = id });
+	        });
+
         // Map MCP endpoints (native HTTP transport with streaming support)
         app.MapMcp();  // This registers the /mcp endpoint with full MCP protocol support
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -11,6 +11,7 @@ using OverlayCompanion.UI;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.IO;
+using OverlayCompanion.Web;
 
 namespace OverlayCompanion;
 
@@ -124,6 +125,7 @@ public class Program
         builder.Services.AddSingleton<IModeManager, ModeManager>();
         builder.Services.AddSingleton<ISessionStopService, SessionStopService>();
         builder.Services.AddSingleton<UpdateService>();
+        builder.Services.AddSingleton<IOverlayEventBroadcaster, OverlayEventBroadcaster>();
         builder.Services.AddHttpClient();
 
         // Add MCP server with native HTTP transport using official SDK
@@ -158,6 +160,16 @@ public class Program
 
         // Enable CORS
         app.UseCors();
+
+        // WebSocket for overlay events
+        app.MapOverlayWebSockets();
+
+        // Serve static web client
+        app.MapGet("/", async context =>
+        {
+            context.Response.ContentType = "text/html";
+            await context.Response.SendFileAsync(Path.Combine(AppContext.BaseDirectory, "wwwroot", "index.html"));
+        });
 
         // Map MCP endpoints (native HTTP transport with streaming support)
         app.MapMcp();  // This registers the /mcp endpoint with full MCP protocol support

--- a/src/Web/OverlayEventBroadcaster.cs
+++ b/src/Web/OverlayEventBroadcaster.cs
@@ -1,0 +1,97 @@
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using OverlayCompanion.Models;
+
+namespace OverlayCompanion.Web;
+
+public interface IOverlayEventBroadcaster
+{
+    Guid AddClient(WebSocket socket, IDictionary<string, string>? meta = null);
+    void RemoveClient(Guid clientId);
+    Task BroadcastOverlayCreatedAsync(OverlayElement overlay);
+    Task BroadcastOverlayRemovedAsync(string overlayId);
+    Task BroadcastClearAsync();
+    int ClientCount { get; }
+}
+
+public class OverlayEventBroadcaster : IOverlayEventBroadcaster
+{
+    private readonly ConcurrentDictionary<Guid, WebSocket> _clients = new();
+
+    public int ClientCount => _clients.Count;
+
+    public Guid AddClient(WebSocket socket, IDictionary<string, string>? meta = null)
+    {
+        var id = Guid.NewGuid();
+        _clients[id] = socket;
+        return id;
+    }
+
+    public void RemoveClient(Guid clientId)
+    {
+        if (_clients.TryRemove(clientId, out var socket))
+        {
+            try { socket.Abort(); } catch { /* ignore */ }
+            try { socket.Dispose(); } catch { /* ignore */ }
+        }
+    }
+
+    public Task BroadcastOverlayCreatedAsync(OverlayElement overlay)
+        => BroadcastAsync(new
+        {
+            type = "overlay_created",
+            overlay = new
+            {
+                id = overlay.Id,
+                x = overlay.Bounds.X,
+                y = overlay.Bounds.Y,
+                width = overlay.Bounds.Width,
+                height = overlay.Bounds.Height,
+                color = overlay.Color,
+                opacity = overlay.Opacity,
+                monitor_index = overlay.MonitorIndex,
+                created_at = overlay.CreatedAt
+            }
+        });
+
+    public Task BroadcastOverlayRemovedAsync(string overlayId)
+        => BroadcastAsync(new { type = "overlay_removed", overlay_id = overlayId });
+
+    public Task BroadcastClearAsync() => BroadcastAsync(new { type = "clear_overlays" });
+
+    private async Task BroadcastAsync(object payload)
+    {
+        if (_clients.IsEmpty) return;
+
+        var json = JsonSerializer.Serialize(payload);
+        var buffer = Encoding.UTF8.GetBytes(json);
+        var segment = new ArraySegment<byte>(buffer);
+
+        var dead = new List<Guid>();
+        foreach (var kv in _clients)
+        {
+            var id = kv.Key;
+            var ws = kv.Value;
+            if (ws.State != WebSocketState.Open)
+            {
+                dead.Add(id);
+                continue;
+            }
+            try
+            {
+                await ws.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+            catch
+            {
+                dead.Add(id);
+            }
+        }
+        // Cleanup dead sockets
+        foreach (var d in dead)
+        {
+            RemoveClient(d);
+        }
+    }
+}

--- a/src/Web/WebSocketEndpoints.cs
+++ b/src/Web/WebSocketEndpoints.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using System.Net.WebSockets;
+using System.Text.Json;
 using OverlayCompanion.Web;
+using OverlayCompanion.Services;
 
 namespace OverlayCompanion.Web;
 
@@ -11,7 +13,7 @@ public static class WebSocketEndpoints
     {
         app.UseWebSockets();
 
-        app.Map("/ws/overlays", async (HttpContext context, IOverlayEventBroadcaster broadcaster) =>
+        app.Map("/ws/overlays", async (HttpContext context, IOverlayEventBroadcaster broadcaster, IOverlayService overlayService) =>
         {
             if (!context.WebSockets.IsWebSocketRequest)
             {
@@ -23,10 +25,36 @@ public static class WebSocketEndpoints
             using var socket = await context.WebSockets.AcceptWebSocketAsync();
             var id = broadcaster.AddClient(socket);
 
+            // Proactively sync current overlay state to the new viewer
+            try
+            {
+                var current = await overlayService.GetActiveOverlaysAsync();
+                var payload = new
+                {
+                    type = "sync_state",
+                    overlays = current.Select(o => new
+                    {
+                        id = o.Id,
+                        x = o.Bounds.X,
+                        y = o.Bounds.Y,
+                        width = o.Bounds.Width,
+                        height = o.Bounds.Height,
+                        color = o.Color,
+                        opacity = o.Opacity,
+                        monitor_index = o.MonitorIndex,
+                        created_at = o.CreatedAt
+                    }).ToArray()
+                };
+                var json = JsonSerializer.Serialize(payload);
+                var seg = new ArraySegment<byte>(System.Text.Encoding.UTF8.GetBytes(json));
+                await socket.SendAsync(seg, WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+            catch { /* best-effort */ }
+
             try
             {
                 var buffer = new byte[1024];
-                // Keep the socket alive; no commands expected from client yet
+                // Keep the socket alive; accept but ignore client messages for now
                 while (socket.State == WebSocketState.Open)
                 {
                     var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);

--- a/src/Web/WebSocketEndpoints.cs
+++ b/src/Web/WebSocketEndpoints.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System.Net.WebSockets;
+using OverlayCompanion.Web;
+
+namespace OverlayCompanion.Web;
+
+public static class WebSocketEndpoints
+{
+    public static void MapOverlayWebSockets(this WebApplication app)
+    {
+        app.UseWebSockets();
+
+        app.Map("/ws/overlays", async (HttpContext context, IOverlayEventBroadcaster broadcaster) =>
+        {
+            if (!context.WebSockets.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Expected WebSocket request");
+                return;
+            }
+
+            using var socket = await context.WebSockets.AcceptWebSocketAsync();
+            var id = broadcaster.AddClient(socket);
+
+            try
+            {
+                var buffer = new byte[1024];
+                // Keep the socket alive; no commands expected from client yet
+                while (socket.State == WebSocketState.Open)
+                {
+                    var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    if (result.CloseStatus.HasValue) break;
+                }
+            }
+            finally
+            {
+                broadcaster.RemoveClient(id);
+            }
+        });
+    }
+}

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -9,8 +9,10 @@
     #container { position: relative; width: 100%; height: 100%; overflow: hidden; background: #000; }
     #viewer { position: absolute; inset: 0; background: #222; color: #eee; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif; }
     #overlay { position: absolute; inset: 0; pointer-events: none; }
-    .box { position: absolute; border: 2px solid red; background: rgba(255,0,0,0.2); box-sizing: border-box; }
+    .box { position: absolute; border: 2px solid red; background: rgba(255,0,0,0.2); box-sizing: border-box; border-radius: 4px; }
     #hud { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.5); color: #fff; padding: 6px 10px; border-radius: 6px; font-family: system-ui, sans-serif; font-size: 12px; }
+    /* ensure overlay canvas never steals input; explicit for clarity */
+    #overlay, .box { pointer-events: none; }
   </style>
 </head>
 <body>

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Overlay Companion - Viewer</title>
+  <style>
+    html, body { height: 100%; margin: 0; background: #111; }
+    #container { position: relative; width: 100%; height: 100%; overflow: hidden; background: #000; }
+    #viewer { position: absolute; inset: 0; background: #222; color: #eee; display: flex; align-items: center; justify-content: center; font-family: system-ui, sans-serif; }
+    #overlay { position: absolute; inset: 0; pointer-events: none; }
+    .box { position: absolute; border: 2px solid red; background: rgba(255,0,0,0.2); box-sizing: border-box; }
+    #hud { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.5); color: #fff; padding: 6px 10px; border-radius: 6px; font-family: system-ui, sans-serif; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <div id="container">
+    <div id="viewer">Stub Viewer (CI-safe). Real setup uses Guacamole here.</div>
+    <div id="overlay"></div>
+    <div id="hud">Click-through overlays enabled. Pointer events go to the viewer behind.</div>
+  </div>
+  <script>
+  // Basic client that draws click-through overlays from the MCP server
+  (function() {
+    const overlayEl = document.getElementById('overlay');
+    const params = new URLSearchParams(location.search);
+    // Viewport crop for multi-window mode
+    const vx = parseInt(params.get('vx')||'0', 10);
+    const vy = parseInt(params.get('vy')||'0', 10);
+    const vw = parseInt(params.get('vw')||window.innerWidth, 10);
+    const vh = parseInt(params.get('vh')||window.innerHeight, 10);
+    const scale = parseFloat(params.get('scale')||'1');
+
+    function intersects(x, y, w, h) {
+      return !(x + w <= vx || y + h <= vy || x >= vx + vw || y >= vy + vh);
+    }
+
+    function toLocalRect(x, y, w, h) {
+      return {
+        left: (x - vx) * scale,
+        top: (y - vy) * scale,
+        width: w * scale,
+        height: h * scale,
+      };
+    }
+
+    function drawBox(data) {
+      const { x, y, width, height, color, opacity } = data;
+      if (!intersects(x, y, width, height)) return;
+      const rect = toLocalRect(x, y, width, height);
+      const el = document.createElement('div');
+      el.className = 'box';
+      el.style.left = rect.left + 'px';
+      el.style.top = rect.top + 'px';
+      el.style.width = rect.width + 'px';
+      el.style.height = rect.height + 'px';
+      el.style.borderColor = color || 'red';
+      el.style.backgroundColor = color ? hexOrNameToRgba(color, opacity ?? 0.25) : 'rgba(255,0,0,0.25)';
+      el.dataset.id = data.id;
+      overlayEl.appendChild(el);
+    }
+
+    function removeBox(id) {
+      const el = overlayEl.querySelector(`.box[data-id="${id}"]`);
+      if (el) el.remove();
+    }
+
+    function clearAll() { overlayEl.innerHTML = ''; }
+
+    function hexOrNameToRgba(color, opacity) {
+      const ctx = document.createElement('canvas').getContext('2d');
+      if (!ctx) return `rgba(255,0,0,${opacity})`;
+      ctx.fillStyle = color;
+      const computed = ctx.fillStyle; // normalized
+      // If rgb(a), just inject opacity
+      if (computed.startsWith('rgb')) {
+        const nums = computed.match(/\d+\.?\d*/g) || [];
+        const [r,g,b] = nums.map(Number);
+        return `rgba(${r},${g},${b},${opacity})`;
+      }
+      // Simplistic hex parse fallback
+      const hex = computed.replace('#','');
+      const bigint = parseInt(hex, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r},${g},${b},${opacity})`;
+    }
+
+    function connect() {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(`${proto}://${location.host}/ws/overlays`);
+      ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.type === 'overlay_created') drawBox(msg.overlay);
+          else if (msg.type === 'overlay_removed') removeBox(msg.overlay_id);
+          else if (msg.type === 'clear_overlays') clearAll();
+        } catch (e) {
+          console.error('WS parse error', e);
+        }
+      };
+      ws.onclose = () => setTimeout(connect, 1000);
+    }
+
+    connect();
+    window.addEventListener('resize', () => {
+      // In real app, we’d broadcast viewport changes; stub keeps it simple.
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -98,6 +98,10 @@
           if (msg.type === 'overlay_created') drawBox(msg.overlay);
           else if (msg.type === 'overlay_removed') removeBox(msg.overlay_id);
           else if (msg.type === 'clear_overlays') clearAll();
+          else if (msg.type === 'sync_state' && Array.isArray(msg.overlays)) {
+            clearAll();
+            for (const o of msg.overlays) drawBox(o);
+          }
         } catch (e) {
           console.error('WS parse error', e);
         }


### PR DESCRIPTION
Summary
- Introduces a web-first path for overlays with guaranteed click-through using CSS pointer-events: none
- Adds a WebSocket overlay broadcast from the MCP server and serves a minimal web client

What’s in this PR
- New IOverlayEventBroadcaster and OverlayEventBroadcaster that fan out overlay events to connected WebSocket clients
- Web endpoint /ws/overlays for browser clients to subscribe to overlay events
- Serve a stub viewer at / (wwwroot/index.html) that renders overlays in an absolutely-positioned layer with pointer-events: none so clicks pass through to the viewer below
- OverlayService now broadcasts create/remove/clear events to connected browsers
- Program.cs wires the broadcaster and maps the WS endpoint; OverlayCompanion.csproj includes web assets in publish

User impact
- Clicking "Test Click-Through Overlay" now shows a full-screen demo overlay and, in parallel, the web client can render the same overlays in a click-through browser layer. This resolves the inability to click underlying content in the demo by moving to a browser overlay that guarantees pass-through.

Notes
- This is the first slice towards the web-first architecture described in SPECIFICATION.md/README.md. The stub viewer is CI-safe and will later be replaced by a Guacamole RDP canvas.
- HEADLESS=1 still uses the mock overlay window while continuing to broadcast to the browser.

Next steps (tracked in ROADMAP)
- Replace the stub viewer with Guacamole canvas
- Multi-window launcher and viewport cropping via URL params (scaffolded)
- Playwright tests for click-through verification and multi-window sync

Co-authored-by: openhands <openhands@all-hands.dev>

@RyansOpenSauceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/409ec25972e34714be3b4ef828b591ee)