### PR TITLE
hotfix: Fix Fedora Silverblue ISO download 404 error

### DIFF
--- a/release/install.sh
+++ b/release/install.sh
@@ -229,9 +229,9 @@ cache_fedora_image() {
     local images_dir="$cache_dir/images"
     mkdir -p "$images_dir"
     
-    # Fedora Silverblue 39 (latest stable)
-    local fedora_version="39"
-    local image_name="Fedora-Silverblue-ostree-x86_64-${fedora_version}.iso"
+    # Fedora Silverblue 41 (latest stable)
+    local fedora_version="41"
+    local image_name="Fedora-Silverblue-ostree-x86_64-${fedora_version}-1.4.iso"
     local image_path="$images_dir/$image_name"
     local image_url="https://download.fedoraproject.org/pub/fedora/linux/releases/${fedora_version}/Silverblue/x86_64/iso/${image_name}"
     


### PR DESCRIPTION
# Hotfix: Fix Fedora Silverblue ISO Download 404 Error

## 🚨 Critical Issue Fixed

This hotfix resolves a **critical installation failure** where users encounter a 404 error when the installer tries to download the Fedora Silverblue ISO.

## 🔧 Problem

The install script was attempting to download **Fedora Silverblue 39**, but this version is no longer available at the specified URL, causing installation to fail with:

```
curl: (22) The requested URL returned error: 404
❌ Failed to download Fedora Silverblue image
```

## ✅ Solution

Updated the Fedora Silverblue version from **39** to **41** (latest stable):

- **Version**: `39` → `41`
- **ISO Filename**: Added proper version suffix `-1.4`
- **URL**: Updated to current Fedora release path
- **Caching**: Maintains existing caching functionality

## 📋 Changes Made

### Updated in `release/install.sh`:
```bash
# Before (404 error)
local fedora_version="39"
local image_name="Fedora-Silverblue-ostree-x86_64-${fedora_version}.iso"

# After (working)
local fedora_version="41"
local image_name="Fedora-Silverblue-ostree-x86_64-${fedora_version}-1.4.iso"
```

## 🎯 Impact

- **Fixes**: Installation failure for all new users
- **Maintains**: Existing caching system (no re-downloads on updates)
- **Preserves**: All existing functionality and architecture
- **Improves**: User experience with latest stable Fedora release

## 🧪 Testing

- [x] Verified Fedora 41 ISO URL is accessible
- [x] Confirmed ISO filename format is correct
- [x] Tested caching logic remains intact
- [x] Build passes all pre-commit checks

## 🚀 Urgency

This is a **critical hotfix** that should be merged immediately as it blocks all new installations. The fix is minimal, safe, and only updates the ISO version without affecting any other functionality.

## 📊 Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Critical hotfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## 🔒 Security & Compatibility

- **No security impact**: Only changes ISO version
- **No breaking changes**: Maintains all existing APIs and functionality
- **Backward compatible**: Existing installations unaffected
- **Forward compatible**: Uses latest stable Fedora release

## 📝 Additional Notes

- This fix enables users to successfully complete installation
- The caching system will prevent re-downloading the 2GB ISO on updates
- Fedora 41 is the current stable release (released October 2024)
- No changes to container architecture or MCP functionality

---

**Ready for immediate merge** - This hotfix resolves the critical installation blocker reported by users.

@RyansOpenSauceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dd97534d7d134630b0e6e1fcce4e95a7)