### PR TITLE
Potential fix for code scanning alert no. 34: Use of externally-controlled format string

### DIFF
--- a/infra/server/connection-manager.js
+++ b/infra/server/connection-manager.js
@@ -200,7 +200,7 @@ class ConnectionManager {
             // SECURITY: Sanitize user-controlled values for logging to prevent format string attacks
             const sanitizedHost = String(connection.host || '(unknown)').replace(/[^\w.-]/g, '');
             const sanitizedPort = parseInt(connection.port) || 0;
-            console.error(`🚫 Connection test failed for ${sanitizedHost}:${sanitizedPort}:`, error.message);
+            console.error('🚫 Connection test failed for %s:%s: %s', sanitizedHost, sanitizedPort, error.message);
             return {
                 success: false,
                 error: error.message,


### PR DESCRIPTION
Potential fix for [https://github.com/RyansOpenSauceRice/overlay-companion-mcp/security/code-scanning/34](https://github.com/RyansOpenSauceRice/overlay-companion-mcp/security/code-scanning/34)

To fix this issue, you should ensure untrusted user data (such as `connection.host` and `connection.port`) is never used in a logging format string unless explicitly handled as string data. The safest approach is to pass user-supplied values as arguments via format specifiers, e.g., `console.error('msg: %s:%s:', host, port, error.message)`, rather than interpolating with backticks or concatenation.

More specifically:
- Change the interpolated/backtick string to use format specifiers (`%s`) and pass sanitized user values as separate arguments.
- Optionally, enhance sanitization of `sanitizedHost` and `sanitizedPort` to strip `%` and other format string characters, or simply rely on format string separation as described above.
- Make these changes on line 203 (and contiguous context for clarity) in `infra/server/connection-manager.js`. No new methods/imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
